### PR TITLE
Simple support for Spock Mocking API

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="project">
+    <words>
+      <w>kclass</w>
+    </words>
+  </dictionary>
+</component>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ detekt = "1.23.8"
 junit-platform = "6.0.1"
 kotlin = "2.2.21"
 spock = "2.4-M7-groovy-5.0"
+mockito = "5.20.0"
 
 [plugins]
 asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "4.0.5" }
@@ -27,3 +28,4 @@ junit4 = { module = "junit:junit", version = "4.13.2" }
 kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.11.1" }
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 spock = { module = "org.spockframework:spock-core", version.ref = "spock" }
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/collector/SpockkTransformationContextCollector.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/collector/SpockkTransformationContextCollector.kt
@@ -16,6 +16,7 @@ package io.github.pshevche.spockk.compilation.collector
 
 import io.github.pshevche.spockk.compilation.common.BaseSpockkIrElementTransformer
 import io.github.pshevche.spockk.compilation.common.MutableSpockkTransformationContext
+import io.github.pshevche.spockk.compilation.common.SpockkConstants
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -26,15 +27,11 @@ import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.isClassWithFqName
 import org.jetbrains.kotlin.ir.util.getAllSuperclasses
 import org.jetbrains.kotlin.ir.util.isFakeOverride
-import org.jetbrains.kotlin.name.FqName
 
 @OptIn(UnsafeDuringIrConstructionAPI::class)
 internal class SpockkTransformationContextCollector(
   private val context: MutableSpockkTransformationContext
 ) : BaseSpockkIrElementTransformer() {
-  companion object {
-    private val SPECIFICATION_FQN = FqName("spock.lang.Specification")
-  }
 
   override fun visitClassNew(declaration: IrClass): IrStatement {
     if (isSpecification(declaration)) {
@@ -45,7 +42,9 @@ internal class SpockkTransformationContextCollector(
   }
 
   private fun isSpecification(declaration: IrClass): Boolean =
-    declaration.getAllSuperclasses().any { it.isClassWithFqName(SPECIFICATION_FQN) }
+    declaration.getAllSuperclasses().any {
+      it.isClassWithFqName(SpockkConstants.SPECIFICATION_FQN)
+    }
 
   override fun visitFunctionNew(declaration: IrFunction): IrStatement {
     if (declaration.isFakeOverride) {

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/common/MutableSpockkTransformationContext.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/common/MutableSpockkTransformationContext.kt
@@ -24,15 +24,9 @@ import org.jetbrains.kotlin.ir.types.isClassWithFqName
 import org.jetbrains.kotlin.ir.util.file
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.util.superClass
-import org.jetbrains.kotlin.name.FqName
 
 @OptIn(UnsafeDuringIrConstructionAPI::class)
 internal class MutableSpockkTransformationContext {
-
-  companion object {
-    private val SPECIFICATION_FQN = FqName("spock.lang.Specification")
-  }
-
   private val specs: MutableMap<IrClass, MutableSpecContext> = mutableMapOf()
 
   fun addSpec(spec: IrClass) {
@@ -46,7 +40,7 @@ internal class MutableSpockkTransformationContext {
 
   private fun computeSpecDepth(spec: IrClass): Int {
     val parentSpec = spec.superClass!!
-    if (parentSpec.isClassWithFqName(SPECIFICATION_FQN)) {
+    if (parentSpec.isClassWithFqName(SpockkConstants.SPECIFICATION_FQN)) {
       return 0
     }
 

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/common/SpockkConstants.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/common/SpockkConstants.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.common
+
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+internal object SpockkConstants {
+  val SPOCK_RUNTIME_PKG = FqName("org.spockframework.runtime")
+  val SPECIFICATION_FQN = FqName("spock.lang.Specification")
+  val SPEC_INTERNALS_CLASS_ID = ClassId(SPOCK_RUNTIME_PKG, Name.identifier("SpecInternals"))
+  val KCLASS_JAVA_PROPERTY_ID = CallableId(FqName("kotlin.jvm"), Name.identifier("java"))
+}

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/SpecRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/SpecRewriter.kt
@@ -16,6 +16,7 @@ package io.github.pshevche.spockk.compilation.transformer
 
 import io.github.pshevche.spockk.compilation.common.SpockkTransformationContext.SpecContext
 import io.github.pshevche.spockk.compilation.ir.ContextAwareIrFactory
+import io.github.pshevche.spockk.compilation.transformer.mock.MockingApiTransformer
 import org.jetbrains.kotlin.ir.declarations.IrClass
 
 internal class SpecRewriter(private val irFactory: ContextAwareIrFactory) {
@@ -26,6 +27,7 @@ internal class SpecRewriter(private val irFactory: ContextAwareIrFactory) {
 
   fun rewrite(spec: IrClass, context: SpecContext) {
     annotateSpec(spec, context)
+    rewriteMockingApi(spec)
   }
 
   private fun annotateSpec(spec: IrClass, context: SpecContext) {
@@ -34,4 +36,8 @@ internal class SpecRewriter(private val irFactory: ContextAwareIrFactory) {
 
   private fun specMetadataAnnotation(fileName: String, line: Int) =
     irFactory.constructorCall(SPEC_METADATA_FQN, irFactory.const(fileName), irFactory.const(line))
+
+  private fun rewriteMockingApi(spec: IrClass) {
+    MockingApiTransformer(irFactory, spec).rewriteMockingApi()
+  }
 }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/mock/MockingApiTransformer.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/mock/MockingApiTransformer.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.transformer.mock
+
+import io.github.pshevche.spockk.compilation.common.BaseSpockkIrElementTransformer
+import io.github.pshevche.spockk.compilation.common.SpockkConstants
+import io.github.pshevche.spockk.compilation.ir.ContextAwareIrFactory
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
+import org.jetbrains.kotlin.ir.types.IrTypeSystemContextImpl
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.findDeclaration
+import org.jetbrains.kotlin.ir.util.isSubtypeOf
+import org.jetbrains.kotlin.name.Name
+import java.util.stream.Collectors
+
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+internal class MockingApiTransformer(
+  private val irFactory: ContextAwareIrFactory,
+  private val spec: IrClass
+) : BaseSpockkIrElementTransformer() {
+
+  private val pluginContext = irFactory.pluginContext
+  private val irBuiltIns = pluginContext.symbols.irBuiltIns
+  private val specInternalsClass =
+    pluginContext.referenceClass(SpockkConstants.SPEC_INTERNALS_CLASS_ID)!!
+  private val kClassJavaPropGetter =
+    pluginContext
+      .referenceProperties(SpockkConstants.KCLASS_JAVA_PROPERTY_ID)
+      .first()
+      .owner
+      .getter!!
+
+  companion object {
+
+    private val MOCK_METHODS: Map<Name, Name> =
+      setOf("Mock", "Stub", "Spy")
+        .stream()
+        .collect(
+          Collectors.toMap({ f -> Name.identifier(f) }, { f -> Name.identifier(f + "Impl") })
+        )
+  }
+
+  fun rewriteMockingApi() {
+    spec.declarations.forEach { declaration ->
+      if (declaration is IrFunction || declaration is IrProperty) {
+        declaration.accept(this, null)
+      }
+    }
+  }
+
+  override fun visitVariable(declaration: IrVariable): IrStatement {
+    // We are searching for
+    // var name:Type = Mock(<any-args>)
+    // which will match the Mock() call as initializer, and left-hand-side as variable.
+    var init = declaration.initializer
+    if (init is IrTypeOperatorCall) {
+      // This shall match/skip stuff like !! or implicit null checks after the Mock() initializer
+      // var name = Mock(Runnable::class.java)!!
+      init = init.argument
+    }
+    if (init is IrCall) {
+      processCall(init, declaration)
+      return declaration // We already processed the initializer so do not continue with the
+      // children
+    }
+    return super.visitVariable(declaration)
+  }
+
+  override fun visitCall(expression: IrCall): IrExpression {
+    processCall(expression, null)
+    return super.visitCall(expression)
+  }
+
+  private fun processCall(call: IrCall, variable: IrVariable?) {
+    val owner = call.symbol.owner
+    val methodName = owner.name
+    val mockMethodImplName = MOCK_METHODS[methodName]
+    if (mockMethodImplName != null) {
+      val parent = owner.parent
+      if (parent == spec) {
+        val implArgCount =
+          call.arguments.size +
+            2 // We need two more arguments for String inferredName, Type inferredType, see
+        // SpecInternals Spock class
+        val mockImplMethod: IrSimpleFunction? =
+          findMockImplMethod(mockMethodImplName, implArgCount, call)
+        if (mockImplMethod != null) {
+          rewriteMockCall(call, variable, mockImplMethod)
+        }
+      }
+    }
+  }
+
+  private fun rewriteMockCall(
+    expression: IrCall,
+    variable: IrVariable?,
+    mockImplMethod: IrSimpleFunction
+  ) {
+    // inferredName argument
+    expression.arguments.add(1, mockName(variable))
+    // inferredType argument
+    expression.arguments.add(2, inferMockType(variable))
+    expression.symbol = mockImplMethod.symbol
+  }
+
+  private fun inferMockType(variable: IrVariable?): IrExpression {
+    val classSym = variable?.type?.classOrNull
+    if (variable == null || classSym == null) {
+      return irFactory.constNull()
+    }
+
+    val call = irFactory.call(variable.type, kClassJavaPropGetter.symbol)
+    call.arguments.clear()
+    call.arguments.add(irFactory.classReference(variable.type, classSym))
+
+    return call
+  }
+
+  private fun mockName(variable: IrVariable?): IrConst {
+    val mockName: String?
+    if (variable != null) {
+      mockName = variable.name.toString()
+    } else {
+      mockName = null
+    }
+    val inferredName = irFactory.const(mockName)
+    return inferredName
+  }
+
+  private fun findMockImplMethod(
+    mockMethodImplName: Name,
+    implArgCount: Int,
+    call: IrCall
+  ): IrSimpleFunction? {
+    val ctx: IrTypeSystemContext = IrTypeSystemContextImpl(irBuiltIns)
+    val mockImplMethod: IrSimpleFunction? =
+      specInternalsClass.owner.findDeclaration { m: IrSimpleFunction ->
+        if (m.name == mockMethodImplName && m.parameters.size == implArgCount) {
+          // We ignore the first three arguments: Spec, inferredName and inferredType
+          for (i in 3..<implArgCount) {
+            val callArg =
+              call.arguments[
+                i - 2
+              ] // We only skip two inferredName and inferredType, because the Spec
+            // is passed as first argument.
+
+            val callType = callArg?.type
+            val methodParam = m.parameters[i]
+            val paramType = methodParam.type
+            if (callType != null && !callType.isSubtypeOf(paramType, ctx)) {
+              return@findDeclaration false
+            }
+          }
+          return@findDeclaration true
+        }
+        false
+      }
+    return mockImplMethod
+  }
+}

--- a/spockk-specs/build.gradle.kts
+++ b/spockk-specs/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   testImplementation(libs.kotlin.compile.testing)
 
   testRuntimeOnly(libs.junit.platform.launcher)
+  testRuntimeOnly(libs.mockito)
 
   testFixturesImplementation(projects.spockkCompilerPlugin)
   testFixturesImplementation(projects.spockkCore)
@@ -35,6 +36,9 @@ tasks.test {
   systemProperty("spockk.junitPlatformVersion", libs.versions.junit.platform.get())
   systemProperty("spockk.kotlinVersion", libs.versions.kotlin.get())
   systemProperty("spockk.spockVersion", libs.versions.spock.get())
+  jvmArgs(
+    "-XX:+EnableDynamicAgentLoading" // TO Disable warning about byte-buddy-agent
+  )
 }
 
 powerAssert {

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/mock/MockingApiTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/mock/MockingApiTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.mock
+
+import io.github.pshevche.spockk.lang.expect
+import io.github.pshevche.spockk.lang.given
+import io.github.pshevche.spockk.lang.then
+import io.github.pshevche.spockk.lang.`when`
+import org.spockframework.mock.MockUtil
+import spock.lang.Specification
+
+/** Tests the usage of the underlying Spock MockingApi is working. */
+class MockingApiTest : Specification() {
+
+  fun `Simple Mock interface with Java Class`() {
+    `when`
+    val m = Mock(Runnable::class.java)
+
+    then
+    assert(m != null)
+
+    `when`
+    m.run()
+    then
+    assertIsSpockMock(m)
+    assertMockName(m, "m")
+  }
+
+  fun `Mock interface without variable`() {
+    given
+    Mock(Runnable::class.java)
+
+    expect
+    noExceptionThrown()
+  }
+
+  fun `Mock interface from variable type`() {
+    given
+    val m: Runnable = Mock()
+
+    `when`
+    m.run()
+    then
+    assertIsSpockMock(m)
+    assertMockName(m, "m")
+  }
+
+  fun `MockName uses the variable name`() {
+    `when`
+    val myMock = Mock(Runnable::class.java)
+
+    then
+    assertIsSpockMock(myMock)
+    assertMockName(myMock, "myMock")
+  }
+
+  fun `MockName uses the variable name and var type`() {
+    `when`
+    val myMock: Runnable = Mock()
+
+    then
+    assertIsSpockMock(myMock)
+    assertMockName(myMock, "myMock")
+  }
+
+  fun `Simple Stub interface with Java Class`() {
+    `when`
+    val m = Stub(Runnable::class.java)
+
+    then
+    assert(m != null)
+
+    `when`
+    m.run()
+    then
+    assertIsSpockMock(m)
+  }
+
+  fun `Stub interface from variable type`() {
+    given
+    val m: Runnable = Stub()
+
+    `when`
+    m.run()
+    then
+    assertIsSpockMock(m)
+  }
+
+  fun `Simple Spy instance with Java Class`() {
+    `when`
+    val m = Spy(StringBuilder::class.java)
+
+    then
+    assert(m != null)
+
+    `when`
+    m.append("a")
+
+    then
+    assert(m.toString() == "a")
+    assertIsSpockMock(m)
+  }
+
+  fun `Spy instance from variable type`() {
+    given
+    val m: StringBuilder = Spy()
+
+    `when`
+    m.append("a")
+
+    then
+    assert(m.toString() == "a")
+    assertIsSpockMock(m)
+  }
+
+  fun mockInHelperMethod(): Runnable = Mock(Runnable::class.java)
+
+  fun `Usage in MockingAPI in helper method`() {
+    given
+    val m = mockInHelperMethod()
+
+    `when`
+    m.run()
+    then
+    assertIsSpockMock(m)
+  }
+
+  val mockField = Mock(Runnable::class.java)!!
+
+  fun `Usage in MockingAPI during field initialization`() {
+    `when`
+    mockField.run()
+    then
+    assertIsSpockMock(mockField)
+  }
+
+  private fun assertIsSpockMock(m: Any?) {
+    assert(MockUtil().isMock(m))
+  }
+
+  private fun assertMockName(m: Any?, name: String) {
+    assert(MockUtil().asMock(m)!!.name == name)
+  }
+}


### PR DESCRIPTION
Add simple support for Mock/Stub/Spy API.

This only supports the simple use case of using java classes with the MockingAPI.
