### PR TITLE
Use more verbose kotlin.test assertions

### DIFF
--- a/spockk-specs/build.gradle.kts
+++ b/spockk-specs/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 dependencies {
   testImplementation(projects.spockkCore)
   testImplementation(gradleTestKit())
+  testImplementation(kotlin("test"))
   testImplementation(libs.spock)
   testImplementation(libs.junit.platform.testkit)
   testImplementation(libs.kotlin.compile.testing)
@@ -37,11 +38,18 @@ tasks.test {
   systemProperty("spockk.kotlinVersion", libs.versions.kotlin.get())
   systemProperty("spockk.spockVersion", libs.versions.spock.get())
   jvmArgs(
-    "-XX:+EnableDynamicAgentLoading" // TO Disable warning about byte-buddy-agent
+    "-XX:+EnableDynamicAgentLoading" // To disable warning about byte-buddy-agent
   )
 }
 
 powerAssert {
-  functions = setOf("kotlin.assert")
+  functions =
+    setOf(
+      "kotlin.test.assertContains",
+      "kotlin.test.assertEquals",
+      "kotlin.test.assertFalse",
+      "kotlin.test.assertNotNull",
+      "kotlin.test.assertTrue"
+    )
   includedSourceSets = setOf("test")
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/BaseCompilationTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/BaseCompilationTest.kt
@@ -18,6 +18,8 @@ import io.github.pshevche.spockk.fixtures.compilation.CompilationUtils.compile
 import io.github.pshevche.spockk.fixtures.compilation.CompilationUtils.transform
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import spock.lang.Specification
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCompilerApi::class)
 abstract class BaseCompilationTest : Specification() {
@@ -27,7 +29,7 @@ abstract class BaseCompilationTest : Specification() {
     val aDump = actual.irDump
     val eDump = expected.irDump
 
-    assert(actual.isSuccess() && expected.isSuccess())
-    assert(aDump == eDump)
+    assertTrue(actual.isSuccess() && expected.isSuccess())
+    assertEquals(eDump, aDump)
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/FeatureBlockStructureValidationTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/FeatureBlockStructureValidationTest.kt
@@ -20,6 +20,9 @@ import io.github.pshevche.spockk.lang.then
 import io.github.pshevche.spockk.lang.`when`
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import spock.lang.Specification
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCompilerApi::class)
 class FeatureBlockStructureValidationTest : Specification() {
@@ -38,7 +41,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `accepts valid block sequences (multiple expectations)`() {
@@ -61,7 +64,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `accepts valid block sequences (single expectation with precondition)`() {
@@ -81,7 +84,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `accepts valid block sequences (single expectation with multiple preconditions)`() {
@@ -104,7 +107,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `accepts valid block sequences (single expectation with single action and precondition)`() {
@@ -128,7 +131,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `accepts valid block sequences (single expectation with multiple actions)`() {
@@ -154,7 +157,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `accepts valid block sequences (multiple expectations with single action)`() {
@@ -178,7 +181,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `accepts valid block sequences (multiple expectations with multiple actions)`() {
@@ -204,7 +207,7 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(result.isSuccess())
+    assertTrue(result.isSuccess())
   }
 
   fun `discards invalid block sequences (precondition with missing expectation)`() {
@@ -221,16 +224,15 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(!result.isSuccess())
-    assert(result.compilation.messages.contains("Spec.kt:3:21"))
-    assert(
-      result.compilation.messages.contains(
+    assertFalse(result.isSuccess())
+    assertContains(result.compilation.messages, "Spec.kt:3:21")
+    assertContains(
+      result.compilation.messages,
+      """
+        Problem with `given`
+        Details: Expected to find one of spockk blocks ['and', 'when', 'expect'], but reached the end of the feature method
         """
-            Problem with `given`
-            Details: Expected to find one of spockk blocks ['and', 'when', 'expect'], but reached the end of the feature method
-            """
-          .trimIndent()
-      )
+        .trimIndent()
     )
   }
 
@@ -248,16 +250,15 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(!result.isSuccess())
-    assert(result.compilation.messages.contains("Spec.kt:3:21"))
-    assert(
-      result.compilation.messages.contains(
+    assertFalse(result.isSuccess())
+    assertContains(result.compilation.messages, "Spec.kt:3:21")
+    assertContains(
+      result.compilation.messages,
+      """
+        Problem with `when`
+        Details: Expected to find one of spockk blocks ['and', 'then'], but reached the end of the feature method
         """
-            Problem with `when`
-            Details: Expected to find one of spockk blocks ['and', 'then'], but reached the end of the feature method
-            """
-          .trimIndent()
-      )
+        .trimIndent()
     )
   }
 
@@ -278,16 +279,15 @@ class FeatureBlockStructureValidationTest : Specification() {
       )
 
     then
-    assert(!result.isSuccess())
-    assert(result.compilation.messages.contains("Spec.kt:6:1"))
-    assert(
-      result.compilation.messages.contains(
+    assertFalse(result.isSuccess())
+    assertContains(result.compilation.messages, "Spec.kt:6:1")
+    assertContains(
+      result.compilation.messages,
+      """
+        Problem with `expect`
+        Details: Expected to find one of spockk blocks ['and', 'then'], but encountered 'expect'
         """
-            Problem with `expect`
-            Details: Expected to find one of spockk blocks ['and', 'then'], but encountered 'expect'
-            """
-          .trimIndent()
-      )
+        .trimIndent()
     )
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkE2ETest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkE2ETest.kt
@@ -19,7 +19,10 @@ import io.github.pshevche.spockk.lang.given
 import io.github.pshevche.spockk.lang.then
 import io.github.pshevche.spockk.lang.`when`
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertFalse
 import spock.lang.Specification
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 
 class SpockkE2ETest : Specification() {
 
@@ -35,12 +38,12 @@ class SpockkE2ETest : Specification() {
     val result = workspace.buildAndFail("test")
 
     then
-    assert(result.task(":test")!!.outcome == TaskOutcome.FAILED)
+    assertEquals(TaskOutcome.FAILED, result.task(":test")!!.outcome)
     result.output.let {
-      assert(it.contains("SuccessfulSpec > passing feature 1 PASSED"))
-      assert(it.contains("SuccessfulSpec > passing feature 2 PASSED"))
-      assert(it.contains("FailingSpec > failing feature 1 FAILED"))
-      assert(it.contains("FailingSpec > failing feature 2 FAILED"))
+      assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
+      assertContains(it, "SuccessfulSpec > passing feature 2 PASSED")
+      assertContains(it, "FailingSpec > failing feature 1 FAILED")
+      assertContains(it, "FailingSpec > failing feature 2 FAILED")
     }
   }
 
@@ -54,12 +57,12 @@ class SpockkE2ETest : Specification() {
     val result = workspace.build("test", "--tests", "SuccessfulSpec")
 
     then
-    assert(result.task(":test")!!.outcome == TaskOutcome.SUCCESS)
+    assertEquals(TaskOutcome.SUCCESS, result.task(":test")!!.outcome)
     result.output.let {
-      assert(it.contains("SuccessfulSpec > passing feature 1 PASSED"))
-      assert(it.contains("SuccessfulSpec > passing feature 2 PASSED"))
-      assert(!it.contains("FailingSpec > failing feature 1 FAILED"))
-      assert(!it.contains("FailingSpec > failing feature 2 FAILED"))
+      assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
+      assertContains(it, "SuccessfulSpec > passing feature 2 PASSED")
+      assertFalse(it.contains("FailingSpec > failing feature 1 FAILED"))
+      assertFalse(it.contains("FailingSpec > failing feature 2 FAILED"))
     }
   }
 
@@ -73,12 +76,12 @@ class SpockkE2ETest : Specification() {
     val result = workspace.build("test", "--tests", "SuccessfulSpec.passing feature 1")
 
     then
-    assert(result.task(":test")!!.outcome == TaskOutcome.SUCCESS)
+    assertEquals(TaskOutcome.SUCCESS, result.task(":test")!!.outcome)
     result.output.let {
-      assert(it.contains("SuccessfulSpec > passing feature 1 PASSED"))
-      assert(!it.contains("SuccessfulSpec > passing feature 2 PASSED"))
-      assert(!it.contains("FailingSpec > failing feature 1 FAILED"))
-      assert(!it.contains("FailingSpec > failing feature 2 FAILED"))
+      assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
+      assertFalse(it.contains("SuccessfulSpec > passing feature 2 PASSED"))
+      assertFalse(it.contains("FailingSpec > failing feature 1 FAILED"))
+      assertFalse(it.contains("FailingSpec > failing feature 2 FAILED"))
     }
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
@@ -20,6 +20,8 @@ import io.github.pshevche.spockk.lang.then
 import io.github.pshevche.spockk.lang.`when`
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 
 class SpockkKotlinCompatibilityTest : Specification() {
 
@@ -34,10 +36,10 @@ class SpockkKotlinCompatibilityTest : Specification() {
     val result = workspace.build("test")
 
     then
-    assert(result.task(":test")!!.outcome == TaskOutcome.SUCCESS)
+    assertEquals(TaskOutcome.SUCCESS, result.task(":test")!!.outcome)
     result.output.let {
-      assert(it.contains("SuccessfulSpec > passing feature 1 PASSED"))
-      assert(it.contains("SuccessfulSpec > passing feature 2 PASSED"))
+      assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
+      assertContains(it, "SuccessfulSpec > passing feature 2 PASSED")
     }
   }
 
@@ -50,10 +52,10 @@ class SpockkKotlinCompatibilityTest : Specification() {
     val result = workspace.build("test")
 
     then
-    assert(result.task(":test")!!.outcome == TaskOutcome.SUCCESS)
+    assertEquals(TaskOutcome.SUCCESS, result.task(":test")!!.outcome)
     result.output.let {
-      assert(it.contains("SuccessfulSpec > passing feature 1 PASSED"))
-      assert(it.contains("SuccessfulSpec > passing feature 2 PASSED"))
+      assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
+      assertContains(it, "SuccessfulSpec > passing feature 2 PASSED")
     }
   }
 
@@ -66,10 +68,10 @@ class SpockkKotlinCompatibilityTest : Specification() {
     val result = workspace.build("test")
 
     then
-    assert(result.task(":test")!!.outcome == TaskOutcome.SUCCESS)
+    assertEquals(TaskOutcome.SUCCESS, result.task(":test")!!.outcome)
     result.output.let {
-      assert(it.contains("SuccessfulSpec > passing feature 1 PASSED"))
-      assert(it.contains("SuccessfulSpec > passing feature 2 PASSED"))
+      assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
+      assertContains(it, "SuccessfulSpec > passing feature 2 PASSED")
     }
   }
 
@@ -82,10 +84,10 @@ class SpockkKotlinCompatibilityTest : Specification() {
     val result = workspace.build("test")
 
     then
-    assert(result.task(":test")!!.outcome == TaskOutcome.SUCCESS)
+    assertEquals(TaskOutcome.SUCCESS, result.task(":test")!!.outcome)
     result.output.let {
-      assert(it.contains("SuccessfulSpec > passing feature 1 PASSED"))
-      assert(it.contains("SuccessfulSpec > passing feature 2 PASSED"))
+      assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
+      assertContains(it, "SuccessfulSpec > passing feature 2 PASSED")
     }
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/mock/MockingApiTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/mock/MockingApiTest.kt
@@ -18,8 +18,11 @@ import io.github.pshevche.spockk.lang.expect
 import io.github.pshevche.spockk.lang.given
 import io.github.pshevche.spockk.lang.then
 import io.github.pshevche.spockk.lang.`when`
+import org.junit.jupiter.api.assertNotNull
 import org.spockframework.mock.MockUtil
 import spock.lang.Specification
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /** Tests the usage of the underlying Spock MockingApi is working. */
 class MockingApiTest : Specification() {
@@ -29,10 +32,11 @@ class MockingApiTest : Specification() {
     val m = Mock(Runnable::class.java)
 
     then
-    assert(m != null)
+    assertNotNull(m)
 
     `when`
     m.run()
+
     then
     assertIsSpockMock(m)
     assertMockName(m, "m")
@@ -53,6 +57,7 @@ class MockingApiTest : Specification() {
     `when`
     m.run()
     then
+
     assertIsSpockMock(m)
     assertMockName(m, "m")
   }
@@ -80,10 +85,11 @@ class MockingApiTest : Specification() {
     val m = Stub(Runnable::class.java)
 
     then
-    assert(m != null)
+    assertNotNull(m)
 
     `when`
     m.run()
+
     then
     assertIsSpockMock(m)
   }
@@ -94,6 +100,7 @@ class MockingApiTest : Specification() {
 
     `when`
     m.run()
+
     then
     assertIsSpockMock(m)
   }
@@ -103,13 +110,13 @@ class MockingApiTest : Specification() {
     val m = Spy(StringBuilder::class.java)
 
     then
-    assert(m != null)
+    assertNotNull(m)
 
     `when`
     m.append("a")
 
     then
-    assert(m.toString() == "a")
+    assertEquals("a", m.toString())
     assertIsSpockMock(m)
   }
 
@@ -121,7 +128,7 @@ class MockingApiTest : Specification() {
     m.append("a")
 
     then
-    assert(m.toString() == "a")
+    assertEquals("a", m.toString())
     assertIsSpockMock(m)
   }
 
@@ -133,6 +140,7 @@ class MockingApiTest : Specification() {
 
     `when`
     m.run()
+
     then
     assertIsSpockMock(m)
   }
@@ -142,15 +150,16 @@ class MockingApiTest : Specification() {
   fun `Usage in MockingAPI during field initialization`() {
     `when`
     mockField.run()
+
     then
     assertIsSpockMock(mockField)
   }
 
   private fun assertIsSpockMock(m: Any?) {
-    assert(MockUtil().isMock(m))
+    assertTrue(MockUtil().isMock(m))
   }
 
   private fun assertMockName(m: Any?, name: String) {
-    assert(MockUtil().asMock(m)!!.name == name)
+    assertEquals(MockUtil().asMock(m)!!.name, name)
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/runtime/SpockkTestEngineInheritanceTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/runtime/SpockkTestEngineInheritanceTest.kt
@@ -24,6 +24,7 @@ import io.github.pshevche.spockk.lang.`when`
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod
 import spock.lang.Specification
+import kotlin.test.assertEquals
 
 class SpockkTestEngineInheritanceTest : Specification() {
   fun `discovers feature methods defined both in parent and child`() {
@@ -76,14 +77,14 @@ class SpockkTestEngineInheritanceTest : Specification() {
         .toList()
 
     then
-    assert(
-      features ==
-        listOf(
-          "successful parent feature",
-          "failing parent feature",
-          "successful child feature",
-          "failing child feature"
-        )
+    assertEquals(
+      listOf(
+        "successful parent feature",
+        "failing parent feature",
+        "successful child feature",
+        "failing child feature"
+      ),
+      features
     )
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/runtime/SpockkTestEngineSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/runtime/SpockkTestEngineSmokeTest.kt
@@ -25,6 +25,7 @@ import org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId
 import spock.lang.Specification
 import java.util.stream.Collectors.toSet
+import kotlin.test.assertEquals
 
 class SpockkTestEngineSmokeTest : Specification() {
   fun `discovers test class by class name`() {
@@ -96,7 +97,7 @@ class SpockkTestEngineSmokeTest : Specification() {
     val specIds = events.map { it.testDescriptor.uniqueId.removeLastSegment() }.collect(toSet())
 
     then
-    assert(specIds.count() == 5)
+    assertEquals(5, specIds.count())
   }
 
   fun `executes tests in the declaration order`() {
@@ -108,6 +109,6 @@ class SpockkTestEngineSmokeTest : Specification() {
         .toList()
 
     then
-    assert(features == listOf("successful feature", "failing feature"))
+    assertEquals(listOf("successful feature", "failing feature"), features)
   }
 }


### PR DESCRIPTION
## Description

In contrast to the standard `assert` function, these are more expressive and are supported by IntelliJ when showing a diff between expected and actual values.