### PR TITLE
Add JDK cross-version compatibility tests

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -9,6 +9,16 @@ runs:
       with:
         distribution: temurin
         java-version: 21
+    - name: Setup Java 25
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: 25
+    - name: Set JDK environment variables
+      shell: bash
+      run: |
+        echo "JDK21=$JAVA_HOME_21_X64" >> $GITHUB_ENV
+        echo "JDK25=$JAVA_HOME_25_X64" >> $GITHUB_ENV
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5
     - name: Detect whether running on a PR from a fork

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.configuration-cache=true
 org.gradle.java.installations.auto-download=false
-org.gradle.java.installations.fromEnv=JDK21
+org.gradle.java.installations.fromEnv=JDK21,JDK25
 org.gradle.jvmargs=-Xmx2g "-XX:MaxMetaspaceSize=1g"
 kotlin.daemon.jvmargs=-Xmx1g
 group=io.github.pshevche.spockk

--- a/spockk-specs/build.gradle.kts
+++ b/spockk-specs/build.gradle.kts
@@ -40,6 +40,10 @@ tasks.test {
   systemProperty("spockk.kotlinVersion", libs.versions.kotlin.get())
   systemProperty("spockk.spockVersion", libs.versions.spock.get())
 
+  // JDK paths for cross-version testing
+  systemProperty("spockk.jdk21", System.getenv("JDK21") ?: "")
+  systemProperty("spockk.jdk25", System.getenv("JDK25") ?: "")
+
   jvmArgs(
     "-XX:+EnableDynamicAgentLoading" // To disable warning about byte-buddy-agent
   )

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
@@ -27,11 +27,16 @@ import kotlin.test.assertEquals
 
 class SpockkKotlinCompatibilityTest : Specification() {
 
+  data class KotlinAndJdkVersions(
+    val kotlinVersion: String,
+    val jdkVersion: Int
+  )
+
   val workspace = Workspace()
 
-  fun `supports Kotlin #kotlinVersion`(kotlinVersion: String) {
+  fun `supports #versions`(versions: KotlinAndJdkVersions) {
     given
-    workspace.setup(kotlinVersion)
+    workspace.setup(versions.kotlinVersion, versions.jdkVersion)
     workspace.addSuccessfulSpec()
 
     `when`
@@ -45,12 +50,17 @@ class SpockkKotlinCompatibilityTest : Specification() {
     }
 
     where
-    variable(kotlinVersion).from(
-      "1.8.22",
-      "1.9.25",
-      "2.0.21",
-      "2.1.21",
-      "2.2.21"
-    )
+    variable(versions).from(VERSION_COMBINATIONS)
+  }
+
+  companion object {
+    private val KOTLIN_VERSIONS = listOf("1.8.22", "1.9.25", "2.0.21", "2.1.21", "2.2.21")
+    private val JDK_VERSIONS = listOf(21, 25)
+
+    private val VERSION_COMBINATIONS = KOTLIN_VERSIONS.flatMap { kotlinVersion ->
+      JDK_VERSIONS.map { jdkVersion ->
+        KotlinAndJdkVersions(kotlinVersion, jdkVersion)
+      }
+    }
   }
 }

--- a/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/Workspace.kt
+++ b/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/Workspace.kt
@@ -33,9 +33,15 @@ class Workspace {
   private val buildFile = projectDir.resolve("build.gradle.kts").toFile()
   private val sourcesDir = projectDir.resolve("src/test/kotlin").toFile()
 
-  fun setup(kotlinVersion: String = System.getProperty("spockk.kotlinVersion")) {
+  fun setup(
+    kotlinVersion: String = System.getProperty("spockk.kotlinVersion"),
+    jdkVersion: Int? = null
+  ) {
     configureRepositories()
     applyPlugins(kotlinVersion)
+    if (jdkVersion != null) {
+      configureJdkToolchain(jdkVersion)
+    }
     configureTestTasks()
   }
 
@@ -90,6 +96,20 @@ class Workspace {
             plugins {
                 kotlin("jvm") version "$kotlinVersion"
                 id("io.github.pshevche.spockk") version "latest.integration"
+            }
+            """
+        .trimIndent()
+    )
+  }
+
+  private fun configureJdkToolchain(jdkVersion: Int) {
+    buildFile.appendText(
+      """
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of($jdkVersion)
+                }
             }
             """
         .trimIndent()


### PR DESCRIPTION
## Summary

Extends the Kotlin compatibility test suite to verify that the Spockk compiler plugin works correctly across different JDK versions.

## Changes

- **Extended `Workspace` fixture** to support JDK version configuration via Gradle toolchain
- **Updated `SpockkKotlinCompatibilityTest`** to test combinations of:
  - 5 Kotlin versions: 1.8.22, 1.9.25, 2.0.21, 2.1.21, 2.2.21
  - 2 JDK versions: 21, 25
  - Total: **10 test combinations**
- **Configured CI** to provision JDK 21 and 25 in the `setup-gradle` action
- **Added JDK environment variable exports** for test execution (JDK21, JDK25)

## Test Coverage

The test suite verifies that the Spockk compiler plugin successfully transforms and executes specifications when compiling with different Kotlin compiler versions on different JDK runtimes.

### Why JDK 21 and 25?

- **JDK 21**: Current LTS version, widely adopted
- **JDK 25**: Latest LTS version, ensures forward compatibility

## Implementation Details

### Workspace Fixture

Added optional `jdkVersion` parameter to `setup()` method that injects Gradle toolchain configuration:

```kotlin
java {
    toolchain {
        languageVersion = JavaLanguageVersion.of(jdkVersion)
    }
}
```

### Test Structure

Used a data class to encapsulate version combinations:

```kotlin
data class KotlinAndJdkVersions(
    val kotlinVersion: String,
    val jdkVersion: Int
)
```

The test uses Spock's `where` block with a pre-computed list of all combinations for clean, maintainable test data.

### CI Configuration

Moved JDK setup to the reusable `setup-gradle` action for consistency across workflows:
- Sets up JDK 21 (for Gradle daemon)
- Sets up JDK 25 (for cross-version testing)
- Exports environment variables for both JDKs

## Test Plan

- [x] Tests compile successfully
- [x] Test structure verified (10 combinations generated)
- [ ] CI workflow provisions JDKs correctly
- [ ] Tests pass in CI with proper JDK environment variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)