### PR TITLE
chore: configure kotlin-lsp for Zed and OpenCode

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java temurin-21.0.8+9.0.LTS

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,15 @@
+{
+  "languages": {
+    "Kotlin": {
+      "language_servers": ["kotlin-lsp", "!kotlin-language-server"]
+    }
+  },
+  "lsp": {
+    "kotlin-lsp": {
+      "binary": {
+        "path": "kotlin-lsp",
+        "arguments": ["--stdio"]
+      }
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -5,5 +5,14 @@
   ],
   "instructions": [
     "CONTRIBUTING.md"
-  ]
+  ],
+  "lsp": {
+    "kotlin-ls": {
+      "disabled": true
+    },
+    "kotlin-lsp": {
+      "command": ["kotlin-lsp", "--stdio"],
+      "extensions": [".kt", ".kts"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Switch from fwcd's `kotlin-language-server` to JetBrains' official `kotlin-lsp` for both Zed and OpenCode
- Add `.zed/settings.json` configuring `kotlin-lsp` as the Kotlin language server (disabling the old `kotlin-language-server`)
- Update `opencode.json` to disable the built-in `kotlin-ls` and add `kotlin-lsp` as a custom LSP server for `.kt`/`.kts` files

## Notes

- `kotlin-lsp` must be installed via `brew install JetBrains/utils/kotlin-lsp`
- Diagnostics won't appear in Zed (kotlin-lsp uses pull-based diagnostics, Zed expects push-based)
- Navigation into JAR/ZIP sources (e.g., stdlib, dependencies) shows empty files in Zed due to [zed-industries/zed#49886](https://github.com/zed-industries/zed/issues/49886)