### PR TITLE
chore: apply OpenCode conventions from shared config

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export OPENCODE_CONFIG_DIR="$PWD/.opencode-conventions"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".opencode-conventions"]
+	path = .opencode-conventions
+	url = https://github.com/pshevche/opencode-conventions-config.git

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-java temurin-21.0.8+9.0.LTS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,38 @@ Before starting work on a significant change, please [open an issue](https://git
 ### Prerequisites
 
 - **JDK 21**: Set the `JDK21` environment variable to the JDK path to make it discoverable by Gradle's toolchains.
+- **direnv**: Required to load OpenCode conventions (see OpenCode Setup below)
 - **IntelliJ IDEA**: While any IDE with Kotlin support works, working on Spockk specifications may be tricky, as the IDE support is only provided via the Spockk IntelliJ plugin
+
+### OpenCode Setup
+
+Spockk uses OpenCode with the [pshevche/opencode-conventions-config](https://github.com/pshevche/opencode-conventions-config) shared configuration.
+
+1. Install direnv:
+   ```bash
+   brew install direnv
+   ```
+
+2. Add to your shell (`~/.zshrc`):
+   ```bash
+   eval "$(direnv hook zsh)"
+   ```
+
+3. Clone the repository:
+   ```bash
+   git clone https://github.com/pshevche/spockk.git
+   cd spockk
+   ```
+
+4. Allow direnv to load the configuration:
+   ```bash
+   direnv allow
+   ```
+
+5. Initialize the git submodule:
+   ```bash
+   git submodule update --init --recursive
+   ```
 
 ### Setup Steps
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,11 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": [
-    "superpowers@git+https://github.com/obra/superpowers.git"
-  ],
-  "instructions": [
-    "CONTRIBUTING.md"
-  ],
   "lsp": {
     "kotlin-ls": {
       "disabled": true


### PR DESCRIPTION
## Summary
- Add `opencode-conventions-config` as git submodule (`.opencode-conventions`)
- Create `.envrc` to set `OPENCODE_CONFIG_DIR` for direnv
- Update `opencode.json` to remove duplicate plugin/instructions (loaded via conventions)
- Document OpenCode setup in CONTRIBUTING.md
- Remove leftover `.tool-versions` file

## Test plan
- [x] Verify OpenCode loads superpowers plugin from conventions
- [x] Verify instructions are loaded from conventions
- [x] Verify LSP config is preserved