### PR TITLE
feat(core): bundle Spock API together with Spockk core

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.20" />
+    <option name="version" value="2.3.21" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
   alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.maven.publish) apply false
   alias(libs.plugins.spotless) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.java.installations.fromEnv=JDK21
 org.gradle.jvmargs=-Xmx2g "-XX:MaxMetaspaceSize=1g"
 kotlin.daemon.jvmargs=-Xmx1g
 group=io.github.pshevche.spockk
-version=0.3.2
+version=0.4.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,32 +1,29 @@
 [versions]
 auto-service = "1.1.1"
-detekt = "1.23.8"
 junit-platform = "6.0.3"
 kotlin = "2.3.21"
-spock = "2.4-groovy-5.0"
-mockito = "5.23.0"
 
 [plugins]
 asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "4.0.5" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "6.0.9" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.8" }
 intellij-platform = { id = "org.jetbrains.intellij.platform", version = "2.16.0" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-power-assert = { id = "org.jetbrains.kotlin.plugin.power-assert", version.ref = "kotlin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.1" }
+shadow = { id = "com.gradleup.shadow", version = "9.4.1" }
 spotless = { id = "com.diffplug.spotless", version = "8.5.1" }
 
 [libraries]
 google-autoservice = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
 google-autoservice-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 hamcrest = { module = "org.hamcrest:hamcrest", version = "3.0" }
-junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "junit-platform" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 junit-platform-testkit = { module = "org.junit.platform:junit-platform-testkit", version.ref = "junit-platform" }
 junit4 = { module = "junit:junit", version = "4.13.2" }
 opentest4j = { module = "org.opentest4j:opentest4j", version = "1.3.0" }
 kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.12.1" }
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-spock = { module = "org.spockframework:spock-core", version.ref = "spock" }
-mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+spock = { module = "org.spockframework:spock-core", version = "2.4-groovy-5.0" }
+mockito = { module = "org.mockito:mockito-core", version = "5.23.0" }

--- a/spockk-core/build.gradle.kts
+++ b/spockk-core/build.gradle.kts
@@ -1,12 +1,23 @@
 plugins {
+  alias(libs.plugins.shadow)
   id("spockk.artifact-under-test-producer")
   id("spockk.kotlin-library")
   id("spockk.maven-central-publish")
 }
 
+tasks.shadowJar {
+  archiveClassifier = ""
+  mergeServiceFiles()
+  include("io/github/pshevche/spockk/**")
+  include("org/spockframework/**")
+  include("spock/**")
+  include("META-INF/spockk-core.kotlin_module")
+  include("META-INF/services/org.junit.platform.engine.discovery.DiscoverySelectorIdentifierParser")
+  include("META-INF/services/org.junit.platform.engine.TestEngine")
+}
+
 dependencies {
-  compileOnly(libs.google.autoservice.annotations)
-  implementation(libs.junit.platform.engine)
+  api(libs.spock)
 }
 
 mavenPublishing {

--- a/spockk-docs/build.gradle.kts
+++ b/spockk-docs/build.gradle.kts
@@ -24,7 +24,6 @@ tasks.named("asciidoctor", AsciidoctorTask::class) {
       "imagesdir" to "images",
       "revnumber" to project.property("version"),
       "junitPlatformVersion" to libs.versions.junit.platform.get(),
-      "spockVersion" to libs.versions.spock.get()
     )
   )
 }

--- a/spockk-docs/docs/getting_started.adoc
+++ b/spockk-docs/docs/getting_started.adoc
@@ -11,11 +11,10 @@ To try Spockk in your local environment, clone the https://github.com/pshevche/s
 * Kotlin 2.0.0 or newer
 
 === Configuration
-Spockk consists of four core modules that must be applied to your project to start using its expressive specification syntax.
+Spockk consists of three core modules that must be applied to your project to start using its expressive specification syntax.
 
-The **Spockk Core** module defines the specification syntax that allows definining Spock-like specifications in Kotlin.
-
-The **Spock Core** module provides a `TestEngine` implementation that allows Spockk tests to run on the JUnit Platform.
+The **Spockk Core** module defines the specification syntax that allows defining Spock-like specifications in Kotlin.
+The core module bundles **Spock Core** module providing a `TestEngine` implementation that allows Spockk tests to run on the JUnit Platform.
 
 .Enable the Spockk test engine in your Gradle project
 [source,kotlin,subs="verbatim,attributes"]
@@ -23,7 +22,6 @@ The **Spock Core** module provides a `TestEngine` implementation that allows Spo
 // build.gradle.kts
 
 dependencies {
-    testImplementation("org.spockframework:spock-core:{spockVersion}")
     testImplementation("io.github.pshevche.spockk:spockk-core:{revnumber}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:{junitPlatformVersion}")
 }

--- a/spockk-docs/docs/getting_started.adoc
+++ b/spockk-docs/docs/getting_started.adoc
@@ -14,7 +14,7 @@ To try Spockk in your local environment, clone the https://github.com/pshevche/s
 Spockk consists of three core modules that must be applied to your project to start using its expressive specification syntax.
 
 The **Spockk Core** module defines the specification syntax that allows defining Spock-like specifications in Kotlin.
-The core module bundles **Spock Core** module providing a `TestEngine` implementation that allows Spockk tests to run on the JUnit Platform.
+The core module bundles the **Spock Core** module providing a `TestEngine` implementation that allows Spockk tests to run on the JUnit Platform.
 
 .Enable the Spockk test engine in your Gradle project
 [source,kotlin,subs="verbatim,attributes"]

--- a/spockk-specs/build.gradle.kts
+++ b/spockk-specs/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
   testImplementation(projects.spockkCore)
   testImplementation(gradleTestKit())
   testImplementation(kotlin("test"))
-  testImplementation(libs.spock)
   testImplementation(libs.junit.platform.testkit)
   testImplementation(libs.kotlin.compile.testing)
 
@@ -37,7 +36,6 @@ tasks.test {
     layout.buildDirectory.dir("spockk-specs-workspaces").get().asFile.absolutePath
   )
   systemProperty("spockk.junitPlatformVersion", libs.versions.junit.platform.get())
-  systemProperty("spockk.spockVersion", libs.versions.spock.get())
 
   jvmArgs(
     "-XX:+EnableDynamicAgentLoading" // To disable warning about byte-buddy-agent

--- a/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/Workspace.kt
+++ b/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/Workspace.kt
@@ -120,13 +120,10 @@ class Workspace {
 
             dependencies {
                 testImplementation("io.github.pshevche.spockk:spockk-core:latest.integration")
-                testImplementation("org.spockframework:spock-core:${System.getProperty("spockk.spockVersion")}")
                 testRuntimeOnly("org.junit.platform:junit-platform-launcher:${System.getProperty("spockk.junitPlatformVersion")}")
             }
             tasks.test {
-                useJUnitPlatform {
-                    includeEngines.add("spock")
-                }
+                useJUnitPlatform()
                 testLogging {
                     events.addAll(listOf(
                         org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED,


### PR DESCRIPTION
## Description

Currently, Spockk core required the Spock API to be added to dependencies explicitly. The Spock API is a hard dependency and bundling it with Spockk core streamlines the configuration and reduces the number of dependencies users need to think about by one.