### PR TITLE
feat: support Kotlin 2.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
       pages: write
       id-token: write
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_SIGNING_KEY_ID }}
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_SIGNING_KEY_PASSPHRASE }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,7 +16,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_SIGNING_KEY_ID }}
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_SIGNING_KEY_PASSPHRASE }}

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.21" />
+    <option name="version" value="2.4.0" />
   </component>
 </project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 auto-service = "1.1.1"
 junit-platform = "6.1.0"
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 
 [plugins]
 asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "4.0.5" }
@@ -23,7 +23,7 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 junit-platform-testkit = { module = "org.junit.platform:junit-platform-testkit", version.ref = "junit-platform" }
 junit4 = { module = "junit:junit", version = "4.13.2" }
 opentest4j = { module = "org.opentest4j:opentest4j", version = "1.3.0" }
-kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.12.1" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.13.0" }
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 spock = { module = "org.spockframework:spock-core", version = "2.4-groovy-5.0" }
 mockito = { module = "org.mockito:mockito-core", version = "5.23.0" }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,15 @@
   "extends": [
     "config:recommended",
     ":semanticCommits"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Kotlin monorepo, power-assert, and compile-testing",
+      "groupSlug": "kotlin",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin",
+        "dev.zacsweers.kctfork"
+      ]
+    }
   ]
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,12 +3,11 @@ plugins {
 }
 
 develocity {
-  server = "https://ge.spockframework.org/"
   buildScan {
+    termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+    termsOfUseAgree = "yes"
     publishing {
-      onlyIf {
-        it.isAuthenticated
-      }
+      onlyIf { it.buildResult.failures.isNotEmpty() }
     }
   }
 }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/DeclarationIrBuilder.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/DeclarationIrBuilder.kt
@@ -23,9 +23,9 @@ import org.jetbrains.kotlin.ir.InternalSymbolFinderAPI
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
+import org.jetbrains.kotlin.ir.builders.irAnnotation
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irTry
 import org.jetbrains.kotlin.ir.builders.irVararg
@@ -33,8 +33,8 @@ import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 import org.jetbrains.kotlin.ir.expressions.IrCatch
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetEnumValue
@@ -71,10 +71,10 @@ import org.jetbrains.kotlin.types.Variance
 internal fun DeclarationIrBuilder.irAnnotation(
   className: FqName,
   vararg args: IrExpression
-): IrConstructorCall {
+): IrAnnotation {
   val classSymbol = context.findRequiredClassSymbol(className)
   val constructorSymbol = classSymbol.constructors.first()
-  return irCallConstructor(constructorSymbol, listOf()).apply {
+  return irAnnotation(constructorSymbol).apply {
     args.withIndex().forEach { arguments[it.index] = it.value }
   }
 }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.ir.builders.irInt
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrFunction
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.name.Name
@@ -68,7 +68,7 @@ internal class FeatureRewriter(override val rewriterContext: SpockkIrRewriterCon
     line: Int,
     parameterNames: List<String>,
     blocks: List<FeatureBlock>
-  ): IrConstructorCall =
+  ): IrAnnotation =
     with(irBuilder(feature.symbol)) {
       irAnnotation(
         FEATURE_METADATA_FQN,

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/SpecRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/SpecRewriter.kt
@@ -25,7 +25,7 @@ import io.github.pshevche.spockk.compilation.transformer.parametrization.WhereBl
 import org.jetbrains.kotlin.ir.builders.irInt
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 
 internal class SpecRewriter(override val rewriterContext: SpockkIrRewriterContext) : SpockkIrRewriter {
 
@@ -66,7 +66,7 @@ internal class SpecRewriter(override val rewriterContext: SpockkIrRewriterContex
     spec: IrClass,
     fileName: String,
     line: Int
-  ): IrConstructorCall =
+  ): IrAnnotation =
     with(irBuilder(spec.symbol)) {
       irAnnotation(SPEC_METADATA_FQN, irString(fileName), irInt(line))
     }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/parametrization/WhereBlockRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/parametrization/WhereBlockRewriter.kt
@@ -54,9 +54,9 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrCall
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetField
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
@@ -402,7 +402,7 @@ internal class WhereBlockRewriter(
     function: IrFunction,
     nextDataVariableIndex: Int,
     previousVariables: List<IrVariable>
-  ): IrConstructorCall {
+  ): IrAnnotation {
     val dataVariables =
       rewriteResources.dataProcessorVars.subList(nextDataVariableIndex, rewriteResources.dataProcessorVars.size).map {
         it.name.asString()
@@ -527,7 +527,7 @@ internal class WhereBlockRewriter(
     }
   }
 
-  fun createDataProcessorAnnotation(builder: DeclarationIrBuilder): IrConstructorCall =
+  fun createDataProcessorAnnotation(builder: DeclarationIrBuilder): IrAnnotation =
     builder.irAnnotation(
       DATA_PROCESSOR_METADATA_FQN,
       builder.irStringArray(dataProcessorVars.map { it.name.asString() })

--- a/spockk-core/build.gradle.kts
+++ b/spockk-core/build.gradle.kts
@@ -5,12 +5,29 @@ plugins {
   id("spockk.maven-central-publish")
 }
 
+// Kotlin 2.4.0 changed the naming of the kotlin_module file, making it incompatible with Kotlin 2.3.x and older
+// This task creates a kotlin_module file with the same content under the old name to keep the compiler plugin compatible with older Kotlin versions
+val generateLegacyKotlinModuleMetadata = tasks.register<Copy>("generateLegacyKotlinModuleMetadata") {
+  dependsOn(tasks.compileKotlin)
+  from(layout.buildDirectory.dir("classes/kotlin/main/META-INF")) {
+    include("io.github.pshevche.spockk_spockk-core.kotlin_module")
+    rename("io.github.pshevche.spockk_spockk-core.kotlin_module", "spockk-core.kotlin_module")
+  }
+  into(layout.buildDirectory.dir("classes/kotlin/main/META-INF"))
+}
+
+tasks.jar {
+  dependsOn(generateLegacyKotlinModuleMetadata)
+}
+
 tasks.shadowJar {
+  dependsOn(generateLegacyKotlinModuleMetadata)
   archiveClassifier = ""
   mergeServiceFiles()
   include("io/github/pshevche/spockk/**")
   include("org/spockframework/**")
   include("spock/**")
+  include("META-INF/io.github.pshevche.spockk_spockk-core.kotlin_module")
   include("META-INF/spockk-core.kotlin_module")
   include("META-INF/services/org.junit.platform.engine.discovery.DiscoverySelectorIdentifierParser")
   include("META-INF/services/org.junit.platform.engine.TestEngine")

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
@@ -59,6 +59,7 @@ class SpockkKotlinCompatibilityTest : Specification() {
     kotlinVersion          ; gradleVersion
     KotlinVersions.V2_0_21 ; GradleVersions.V8_8
     KotlinVersions.V2_1_21 ; GradleVersions.V8_12_1
-    KotlinVersions.V2_2_21 ; GradleVersions.V8_14_4
+    KotlinVersions.V2_2_21 ; GradleVersions.V8_14_5
+    KotlinVersions.V2_3_21 ; GradleVersions.V9_3_1
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/e2e/SpockkKotlinCompatibilityTest.kt
@@ -42,6 +42,7 @@ class SpockkKotlinCompatibilityTest : Specification() {
     setup
     workspace.kotlinVersion(kotlinVersion).gradleVersion(gradleVersion).setup()
     workspace.addSuccessfulSpec()
+    workspace.addSpecWithDataPipes()
 
     `when`
     val result = workspace.build("test", "--stacktrace")
@@ -51,6 +52,7 @@ class SpockkKotlinCompatibilityTest : Specification() {
     result.output.let {
       assertContains(it, "SuccessfulSpec > passing feature 1 PASSED")
       assertContains(it, "SuccessfulSpec > passing feature 2 PASSED")
+      assertContains(it, "DataPipeSpec > data pipe feature > data pipe feature")
     }
 
     where

--- a/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/GradleVersions.kt
+++ b/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/GradleVersions.kt
@@ -17,9 +17,8 @@ package io.github.pshevche.spockk.fixtures.e2e
 import org.gradle.util.GradleVersion
 
 object GradleVersions {
-  val V7_6_6: GradleVersion = GradleVersion.version("7.6.6")
-  val V8_1_1: GradleVersion = GradleVersion.version("8.1.1")
   val V8_8: GradleVersion = GradleVersion.version("8.8")
   val V8_12_1: GradleVersion = GradleVersion.version("8.12.1")
-  val V8_14_4: GradleVersion = GradleVersion.version("8.14.4")
+  val V8_14_5: GradleVersion = GradleVersion.version("8.14.5")
+  val V9_3_1: GradleVersion = GradleVersion.version("9.3.1")
 }

--- a/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/KotlinVersions.kt
+++ b/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/KotlinVersions.kt
@@ -18,4 +18,5 @@ object KotlinVersions {
   val V2_0_21: KotlinVersion = KotlinVersion(2, 0, 21)
   val V2_1_21: KotlinVersion = KotlinVersion(2, 1, 21)
   val V2_2_21: KotlinVersion = KotlinVersion(2, 2, 21)
+  val V2_3_21: KotlinVersion = KotlinVersion(2, 3, 21)
 }

--- a/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/Workspace.kt
+++ b/spockk-specs/src/testFixtures/kotlin/io/github/pshevche/spockk/fixtures/e2e/Workspace.kt
@@ -159,6 +159,24 @@ class Workspace {
     )
   }
 
+  fun addSpecWithDataPipes(name: String = "DataPipeSpec") {
+    writeSpec(
+      name,
+      """
+            class $name : spock.lang.Specification() {
+                fun `data pipe feature`(a: Int) {
+                    io.github.pshevche.spockk.lang.expect
+                    assert(a > 0)
+
+                    io.github.pshevche.spockk.lang.where
+                    io.github.pshevche.spockk.lang.variable(a).from(1, 2, 3)
+                }
+            }
+        """
+        .trimIndent()
+    )
+  }
+
   fun addFailingSpec(name: String = "FailingSpec") {
     writeSpec(
       name,


### PR DESCRIPTION
Upgrades the project to Kotlin 2.4.0.

## Changes

- **spockk-core**: Fix shadow jar to include the new Kotlin 2.4.0 `kotlin_module` filename (`io.github.pshevche.spockk_spockk-core.kotlin_module`) alongside the old name for backward compatibility
- **spockk-specs**: Update e2e compatibility test to exercise data pipes, catching missing `kotlin_module` metadata
- **renovate.json**: Group Kotlin monorepo, power-assert, and kctfork updates together