### PR TITLE
docs: add changelogs for 0.4.0

### DIFF
--- a/spockk-docs/docs/changelog.adoc
+++ b/spockk-docs/docs/changelog.adoc
@@ -1,5 +1,11 @@
 == Changelog
 
+=== v0.4.0
+
+- [Core] Added support for Kotlin 2.4.x
+- [Core] Bundle Spock API to avoid declaring Spock as a separate dependency
+- Regular dependency management.
+
 === v0.3.2
 
 - [Core] Allow accessing `@Shared` fields from `setupSpec` and `cleanupSpec` methods

--- a/spockk-intellij-plugin/docs/release-notes.txt
+++ b/spockk-intellij-plugin/docs/release-notes.txt
@@ -1,4 +1,3 @@
 <ul>
-    <li>[NEW] Added syntax support for setup and cleanup block labels</li>
-    <li>[FIX] Suppressed false-positive unreachable code warnings in cleanup and where blocks</li>
+    <li>Regular dependency management.</li>
 </ul>


### PR DESCRIPTION
## Summary
- Added v0.4.0 section to `spockk-docs/docs/changelog.adoc` covering Kotlin 2.4.x support, bundled Spock API, and dependency management
- Updated `spockk-intellij-plugin/docs/release-notes.txt` with v0.4.0 entries, removed previous version entries

## Test Plan
- [x] `:spockk-specs:test` passes