### PR TITLE
chore: prepare 0.4.1 release

### DIFF
--- a/spockk-docs/docs/changelog.adoc
+++ b/spockk-docs/docs/changelog.adoc
@@ -1,5 +1,10 @@
 == Changelog
 
+=== v0.4.1
+
+- [IntelliJ Plugin] Added support for IntelliJ 2026.2
+- Regular dependency management.
+
 === v0.4.0
 
 - [Core] Added support for Kotlin 2.4.x

--- a/spockk-intellij-plugin/docs/release-notes.txt
+++ b/spockk-intellij-plugin/docs/release-notes.txt
@@ -1,3 +1,4 @@
 <ul>
+    <li>Added support for IntelliJ 2026.2.</li>
     <li>Regular dependency management.</li>
 </ul>


### PR DESCRIPTION
Prepare 0.4.1 release.

## Changelog
- [IntelliJ Plugin] Added support for IntelliJ 2026.2
- Regular dependency management (Kotlin 2.4.10, JUnit 6.1.2, Shadow, Spotless, IntelliJ Platform)

## Files
- `spockk-docs/docs/changelog.adoc`
- `spockk-intellij-plugin/docs/release-notes.txt`