### PR TITLE
fix(docs): set base path for GitHub Pages project site

### DIFF
--- a/spockk-docs/docs/.vitepress/config.mts
+++ b/spockk-docs/docs/.vitepress/config.mts
@@ -25,12 +25,16 @@ export default defineConfig({
   title: 'Spockk',
   description: "Spock's expressive specification syntax, natively in Kotlin.",
   lang: 'en-US',
+  // GitHub Pages serves this as a project site under /spockk/, not at
+  // the domain root, so every generated asset URL needs this prefix
+  // or it 404s against the domain root instead.
+  base: '/spockk/',
   outDir: '../build/docs',
   cleanUrls: true,
   lastUpdated: false,
 
   head: [
-    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/images/icon_with_background.svg' }],
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: 'images/icon_with_background.svg' }],
     ['meta', { name: 'theme-color', content: '#844dfd' }],
   ],
 

--- a/spockk-docs/docs/examples.md
+++ b/spockk-docs/docs/examples.md
@@ -146,7 +146,7 @@ class WarpCoreSpec : Specification() {
 </CodeCarousel>
 
 <div class="page-nav">
-  <a class="page-nav-next" href="/limitations">
+  <a class="page-nav-next" href="limitations">
     <span class="page-nav-label">Next</span>
     <span class="page-nav-title">Limitations →</span>
   </a>

--- a/spockk-docs/docs/getting-started.md
+++ b/spockk-docs/docs/getting-started.md
@@ -75,7 +75,7 @@ Setting up an existing project takes three small steps.
 </div>
 
 <div class="page-nav">
-  <a class="page-nav-next" href="/examples">
+  <a class="page-nav-next" href="examples">
     <span class="page-nav-label">Next</span>
     <span class="page-nav-title">Examples →</span>
   </a>

--- a/spockk-docs/docs/index.md
+++ b/spockk-docs/docs/index.md
@@ -14,8 +14,8 @@ description: Spock's expressive specification syntax, natively in Kotlin.
       down to genuine Spock specifications.
     </p>
     <div class="spockk-hero-actions">
-      <a class="spockk-btn spockk-btn-brand" href="/examples">See it in action</a>
-      <a class="spockk-btn spockk-btn-alt" href="/getting-started">Get Started</a>
+      <a class="spockk-btn spockk-btn-brand" href="examples">See it in action</a>
+      <a class="spockk-btn spockk-btn-alt" href="getting-started">Get Started</a>
       <a class="spockk-btn spockk-btn-alt" href="https://github.com/pshevche/spockk">GitHub ↗</a>
     </div>
   </div>
@@ -73,7 +73,7 @@ class WelcomeSpec : Specification() {
 </div>
 
 <div class="page-nav">
-  <a class="page-nav-next" href="/getting-started">
+  <a class="page-nav-next" href="getting-started">
     <span class="page-nav-label">Next</span>
     <span class="page-nav-title">Getting Started →</span>
   </a>

--- a/spockk-docs/docs/limitations.md
+++ b/spockk-docs/docs/limitations.md
@@ -35,7 +35,7 @@ Spockk is in active development, and it falls short of writing a specification d
 These and other improvements are on the roadmap. Stay tuned for future releases!
 
 <div class="page-nav">
-  <a class="page-nav-next" href="/changelog">
+  <a class="page-nav-next" href="changelog">
     <span class="page-nav-label">Next</span>
     <span class="page-nav-title">Changelog →</span>
   </a>


### PR DESCRIPTION
## Summary

- The deployed site (`pshevche.github.io/spockk/`) is a GitHub Pages *project* site, served under the `/spockk/` subpath, not the domain root. VitePress defaulted to `base: '/'`, so every generated asset URL (scripts, styles, images) pointed at the domain root and 404'd, leaving the page as unstyled, unmounted raw HTML.
- Set `base: '/spockk/'` in `config.mts`, which fixes VitePress's own generated links (nav, logo, page assets).
- That alone doesn't cover hand-written raw HTML hrefs in the markdown (hero buttons, page-nav "Next" links) or the favicon in `config.mts`'s `head` array, since base-prefixing only applies to VitePress's own components and markdown-syntax links. Switched those to relative paths, which resolve correctly under any base since every page here is a flat sibling under the same directory.

## Test plan

- [x] `pnpm run build` succeeds
- [x] `pnpm run lint` / `pnpm run format:check` pass
- [x] `./gradlew :spockk-docs:build` succeeds
- [x] Verified with a local server rooted at `/spockk/`: all five pages load with zero failed requests, both via direct navigation and via the client-side router
- [ ] Re-run the `publish.yml` workflow after merging to redeploy the fixed site

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QBLWKCbEEC5FKVan6Sdds7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBLWKCbEEC5FKVan6Sdds7)_