### PR TITLE
feat: support thrown()/notThrown()/noExceptionThrown() exception conditions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,9 @@ Spockk is a Kotlin compiler plugin that brings Spock-style BDD testing syntax to
 ## Tech Stack
 
 - Kotlin 2.4.10, JDK 21 (toolchain)
-- Gradle 9.6.1 with version catalog (`gradle/libs.versions.toml`)
+- Gradle 9.7.1 with version catalog (`gradle/libs.versions.toml`)
 - Convention plugins in `gradle/plugins/`
-- JUnit Platform 6.0.3, Spock 2.4-groovy-5.0
+- JUnit Platform 6.1.3, Spock 2.4-groovy-5.0
 
 ## Build Commands
 

--- a/_docs/plans/2026-08-09-exception-conditions.md
+++ b/_docs/plans/2026-08-09-exception-conditions.md
@@ -1,0 +1,108 @@
+# Exception Conditions Implementation Plan
+
+**Goal:** Make Spock's `thrown(Type)`, `notThrown(Type)`, `noExceptionThrown()` exception-condition helpers work in
+Spockk. A `when` block immediately followed by a `then` block containing one of these calls gets its statements
+wrapped in a try/catch that records the thrown exception (if any) on `SpecificationContext`; `thrown(Type::class.java)`
+is rewritten to call Spock's own already-shaded `SpecInternals.checkExceptionThrown`; `notThrown`/`noExceptionThrown`
+need no call-site rewriting at all since their real inherited bodies already read the recorded exception correctly.
+
+**Architecture:** New `WhenBlockRewriter` (mirrors `CleanupBlockRewriter`'s try/catch-wrapping pattern - no variable
+hoisting needed, Kotlin IR resolves locals by symbol not lexical nesting) wraps a `when` block's statements when its
+paired `then` block needs it. A new, separate, non-recursive `ExceptionConditionRewriter` scans a `then` block's own
+top-level statements for exception-condition calls, rewrites `thrown(Type)` calls, and validates at-most-one -
+deliberately kept out of the existing shared `ConditionStatementsRewriter` (used for `then`/`expect`/`verify`/
+`verifyAll`/`verifyEach`/helper methods) to avoid complicating that recursive abstraction with a then-block-only,
+non-recursive concern. `FeatureRewriter` pre-scans `featureBody.behaviorBlocks` once to find WHEN/THEN pairs that
+need this treatment (a WHEN block in `behaviorBlocks` is always immediately followed by exactly one THEN block, per
+`BlockOrderValidatingFeatureStatementsCollector`'s state machine).
+
+See design doc: `_docs/specs/2026-08-09-exception-conditions-design.md`
+
+**Tech Stack:** Kotlin IR, Spock runtime (shaded `SpecInternals`, `SpecificationContext`, `WrongExceptionThrownError`,
+`UnallowedExceptionThrownError`, `InvalidSpecException`)
+
+---
+
+### Task 1: Add IR identifiers and detectors
+
+**Files:**
+- Modify: `spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrIdentifiers.kt`
+- Modify: `spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrStatement.kt` (or wherever `isAssertCall()` currently lives - re-locate it first, it may have moved since last read)
+
+- [ ] **Step 1:** Add `THROWN_FQN`, `NOT_THROWN_FQN`, `NO_EXCEPTION_THROWN_FQN` to `IrIdentifiers.Spock`, as children of the existing `SPECIFICATION_FQN` (matching how `WILDCARD_FQN`/`SHARED_ANNOTATION_FQN` are namespaced)
+- [ ] **Step 2:** Add `isExceptionConditionCall(): Boolean` next to `isAssertCall()` - same FqName-match-ignoring-overload technique (`(this as? IrCall)?.symbol?.owner?.fqNameWhenAvailable` against the three new FQNs), matching any of `thrown`/`notThrown`/`noExceptionThrown` regardless of arity
+- [ ] **Step 3:** Add a narrower `isThrownCall(): Boolean` (FqName == `THROWN_FQN` only) for the rewrite step (Task 3) to distinguish "detected, needs rewriting" from "detected, no rewrite needed"
+- [ ] **Step 4:** Run `./gradlew :spockk-compiler-plugin:compileKotlin`, commit
+
+### Task 2: Add runtime call-building wrappers
+
+**Files:**
+- Modify: `spockk-compiler-plugin/.../transformer/ir/IrSpecificationContext.kt`
+- Create: `spockk-compiler-plugin/.../transformer/ir/IrSpecInternals.kt`
+
+- [ ] **Step 1:** In `IrSpecificationContext`, add `irSetThrownException(builder, specAccessor, throwableExprOrNull): IrExpression` - same `getSpecificationContextInstance()` + `specificationContextClass.functionByName("setThrownException")` pattern already used for `irSetCurrentBlock`
+- [ ] **Step 2:** Create `IrSpecInternals`, mirroring `IrSpockRuntime`'s one-wrapper-class-per-Spock-class convention: resolve `SPEC_INTERNALS_FQN` (already declared in `IrIdentifiers.kt`, currently unused) once via `findRequiredClassSymbol`, expose `irCheckExceptionThrown(builder, specAccessor, exceptionTypeClassExpr): IrCall` building a static call to `SpecInternals.checkExceptionThrown(Specification, Class<? extends Throwable>)` (`functionByName("checkExceptionThrown")`, `arguments[0] = irGet(specAccessor)`, `arguments[1] = exceptionTypeClassExpr`)
+- [ ] **Step 3:** Wire `IrSpecInternals` into `SpockkIrRewriterContext` (same place `spockRuntime`/`IrSpockRuntime` is constructed), so it's reachable the same way (`rewriterContext.specInternals.irCheckExceptionThrown(...)`)
+- [ ] **Step 4:** Run `./gradlew :spockk-compiler-plugin:compileKotlin`, commit
+
+### Task 3: Add `ExceptionConditionRewriter` (detection, `thrown` rewrite, validation)
+
+**Files:**
+- Create: `spockk-compiler-plugin/.../transformer/condition/ExceptionConditionRewriter.kt`
+- Create: `spockk-compiler-plugin/.../transformer/condition/InvalidExceptionConditionExceptionFactory.kt` (mirrors `InvalidParametrizationExceptionFactory`)
+
+- [ ] **Step 1:** Add a scan helper: given a `THEN` block's statement list, find all top-level exception-condition calls - checking both bare `IrExpression` statements (`isExceptionConditionCall()`) and `IrVariable.initializer` expressions (a `val e = thrown(...)` shape) - returning enough info to know count (for validation) and, for `thrown` specifically, where to substitute
+- [ ] **Step 2:** `InvalidExceptionConditionExceptionFactory(file, irElement)` - one factory method, `multipleExceptionConditionsException()`, message text adapted from Spock's ("A 'then' block may only have a single exception condition"), throwing `CompilationException` (same `org.jetbrains.kotlin.backend.common.CompilationException(message, file, irElement)` constructor `InvalidParametrizationExceptionFactory` uses)
+- [ ] **Step 3:** `ExceptionConditionRewriter.rewrite(statements: List<IrStatement>): List<IrStatement>` - if more than one exception-condition call found, throw via the new factory; otherwise, for the single `thrown(...)` match (if any - `notThrown`/`noExceptionThrown` need no rewrite per the design doc), substitute in place: for a bare statement, replace it with `irAs(specInternals.irCheckExceptionThrown(builder, feature.requiredThisParameter(), originalCallArg), originalCall.type)`; for a `val`/`var` declaration, mutate `IrVariable.initializer` the same way (matching the existing in-place-mutation style `ConditionStatementsRewriter.rewriteHelperCallLambdaBody` already uses on `lambdaStatements`)
+- [ ] **Step 4:** Add a `fun List<IrStatement>.hasExceptionCondition(): Boolean` used by Task 5's when-block-pairing pre-scan (same detection as Step 1, boolean form)
+- [ ] **Step 5:** Run `./gradlew :spockk-compiler-plugin:compileKotlin`, commit
+
+### Task 4: Add `WhenBlockRewriter`
+
+**Files:**
+- Create: `spockk-compiler-plugin/.../transformer/condition/WhenBlockRewriter.kt`
+
+- [ ] **Step 1:** `WhenBlockRewriter(rewriterContext, feature, whenBlock: FeatureBlock).rewrite(): List<IrStatement>` - mirrors `CleanupBlockRewriter`'s shape: `specificationContext.irSetThrownException(builder, specAccessor, irNull())`, then `callBlockEntered`, then `irTry(tryExpressions = whenBlock.statements, catchExpressions = [irCatch(catchVar, specificationContext.irSetThrownException(builder, specAccessor, irGet(catchVar)))], finallyExpressions = [])` (no rethrow - the exception is consumed), then `callBlockExited`. No variable hoisting (see design doc's simplification #3 - `CleanupBlockRewriter` is direct existing proof this is safe)
+- [ ] **Step 2:** Run `./gradlew :spockk-compiler-plugin:compileKotlin`, commit
+
+### Task 5: Wire into `FeatureRewriter`
+
+**Files:**
+- Modify: `spockk-compiler-plugin/.../transformer/FeatureRewriter.kt`
+
+- [ ] **Step 1:** Re-read `rewriteBehaviorStatements` in full first (confirm it hasn't changed further since this session's research) before editing
+- [ ] **Step 2:** Before the main loop, pre-scan `featureBody.behaviorBlocks`: for each `WHEN` block at index `i`, check whether `behaviorBlocks[i+1]` (guaranteed to be the paired `THEN` block) has an exception condition (`hasExceptionCondition()` from Task 3); collect the set of WHEN-block ordinals (or indices) needing wrapping
+- [ ] **Step 3:** Change the main loop from `forEach` to an indexed iteration (`withIndex()`). For a `WHEN` block in the needs-wrapping set: route through `WhenBlockRewriter` instead of the generic `else` branch. For a `THEN` block whose *previous* block was a wrapped `WHEN`: run `ExceptionConditionRewriter.rewrite(it.statements)` first, then pass the result into the existing (unmodified) `ConditionRewriter(...).rewrite(...)` exactly as today. Every other block (`SETUP`/`GIVEN`/unpaired `WHEN`/`EXPECT`/unpaired `THEN`) is unchanged
+- [ ] **Step 4:** Run `./gradlew :spockk-compiler-plugin:compileKotlin`, commit
+
+### Task 6: Compilation snapshot tests
+
+**Files:**
+- Create: `spockk-specs/src/test/resources/samples/compilation/source/condition/{ThrownBasic,ThrownWithVariable,NotThrown,NoExceptionThrown,WhenBlockWithVariableDefs,MultipleWhenThenPairs,NoExceptionConditionNoWrapping}.kt`
+- Create: matching golden files under `spockk-specs/src/test/resources/samples/compilation/transformed/condition/`
+- Modify/Create: a compilation test class following the existing convention (check `ImplicitConditionsCompilationTest.kt` or equivalent for the exact harness)
+
+- [ ] **Step 1:** `thrown(Type::class.java)` as a bare `then` statement - golden shows when-block wrapped, `thrown` call replaced with the `SpecInternals.checkExceptionThrown` + cast
+- [ ] **Step 2:** `val e = thrown(Type::class.java)` - golden shows the variable's initializer rewritten, not the statement itself
+- [ ] **Step 3:** `notThrown(Type::class.java)` / `noExceptionThrown()` - golden shows when-block wrapped, call itself unchanged
+- [ ] **Step 4:** `when` block with variable declarations later read in `then` - golden confirms no hoisting occurs and the variable remains correctly referenced
+- [ ] **Step 5:** Multiple `when`/`then` pairs in one feature, only one containing an exception condition - golden confirms only the paired `when` gets wrapped
+- [ ] **Step 6:** A `when`/`then` pair with no exception-condition call - golden confirms it's untouched (still the plain `blockEntered`/statements/`blockExited` shape)
+- [ ] **Step 7:** Run `./gradlew :spockk-specs:test --rerun`, fix failures, commit
+
+### Task 7: Update smoke tests
+
+**Files:**
+- Modify: `spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt`
+
+- [ ] **Step 1:** Flip the existing `@FailsWith`-pinned-broken-behavior scenarios to their real, correct outcomes (basic `thrown()` catches; `noExceptionThrown()`/`notThrown()` correctly reject an actual exception with `UnallowedExceptionThrownError`)
+- [ ] **Step 2:** Add scenarios mirroring Spock's own `ExceptionConditions.groovy`: catching `Exception`/`RuntimeException`/`Error`/`Throwable`; wrong exception type -> `WrongExceptionThrownError`; `thrown(null)` -> `InvalidSpecException`; multiple `when`/`then` pairs each with their own exception condition; at-most-one violation -> compile error (likely needs a separate inline-spec-based test per this project's "Error scenarios -> inline specs" convention, using `TestDataFactory.specWithFeatureBody()`/`transform()`, not a smoke test)
+- [ ] **Step 3:** Confirm `expect`-block usage still throws the fallback `InvalidSpecException` unchanged (already-correct case, regression guard)
+- [ ] **Step 4:** Update the class doc comment - it currently describes the gap as unimplemented; correct it to describe what's now supported and what's deferred (linking the design doc)
+- [ ] **Step 5:** Run `./gradlew :spockk-specs:test`, fix failures, commit
+
+### Task 8: Update issue and final verification
+
+- [ ] **Step 1:** Check off completed acceptance criteria on [#271](https://github.com/pshevche/spockk/issues/271); leave deferred items noted as follow-ups, don't close the issue over them
+- [ ] **Step 2:** Run `./gradlew build` (full build: compile, test, spotless, detekt) at the repo root
+- [ ] **Step 3:** Fix any remaining failures, commit, push to `claude/spockk-exception-assertions-88u7de`

--- a/_docs/specs/2026-08-09-exception-conditions-design.md
+++ b/_docs/specs/2026-08-09-exception-conditions-design.md
@@ -1,0 +1,196 @@
+# Exception Conditions: thrown, notThrown, noExceptionThrown
+
+**Date:** 2026-08-09
+**Issue:** [#271](https://github.com/pshevche/spockk/issues/271)
+
+## Context
+
+Spock's exception-condition helpers - `thrown(Type)`, `notThrown(Type)`, `noExceptionThrown()` - let a `then` block
+assert on an exception thrown by the immediately preceding `when` block. Spockk specs extend the real
+`spock.lang.Specification` class directly, so these are inherited Java methods, not Spockk-authored API - but they
+don't work: Spockk's `when` blocks are never wrapped in a try/catch that records the exception anywhere, so
+`thrown(Type)` always throws its own unconditional-fallback `InvalidSpecException`, and `notThrown`/`noExceptionThrown`
+silently no-op. This is pinned as a regression baseline in
+`spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt`. This
+document scopes the real implementation.
+
+## Functional Design
+
+### How Spock Does It
+
+**Runtime API** ([`Specification.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/spock/lang/Specification.java)):
+
+```java
+public <T extends Throwable> T thrown() { throw new InvalidSpecException("..."); }               // line 86-89
+public <T extends Throwable> T thrown(Class<T> type) { throw new InvalidSpecException("..."); }   // line 109-112
+public void notThrown(Class<? extends Throwable> type) { ... }                                    // line 120-127, real body
+public void noExceptionThrown() { ... }                                                            // line 133-137, real body
+```
+
+`thrown()`/`thrown(Class)` are **unconditional-throw fallback bodies** - real, callable JVM methods that only fire
+when the compiler's AST transform didn't rewrite the call site (used outside a `then` block, or not top-level).
+`notThrown`/`noExceptionThrown` have **real working bodies** that read
+`getSpecificationContext().getThrownException()` directly and are **never** AST-rewritten.
+
+**When-block wrapping** ([`SpecRewriter.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java)):
+`visitThenBlock` (lines 500-518) calls `DeepBlockRewriter` to find a top-level exception-condition call
+(`Identifiers.EXCEPTION_CONDITION_METHODS = {thrown, notThrown, noExceptionThrown}`, `.../util/Identifiers.java:95-113`)
+in the `then` block; if found, `rewriteWhenBlockForExceptionCondition(block.getPrevious(WhenBlock.class))`
+(lines 770-800) wraps the **entire** preceding `when` block's statements in:
+
+```
+specificationContext.setThrownException(null)
+try { <when-block statements, unchanged> }
+catch (Throwable t) { specificationContext.setThrownException(t) }   // no rethrow
+```
+
+The `null` reset clears stale state from a previous data-driven iteration or an earlier `when`/`then` pair in the
+same method. Variable declarations inside the `when` block are hoisted to the enclosing method
+(`moveVariableDeclarations`) so they stay in scope for `then` - a Groovy-source-scoping concern (see below for why
+this doesn't apply to Kotlin IR).
+
+**`thrown(Type)` rewriting** ([`SpecialMethodCall.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java) lines 174-220,
+[`DeepBlockRewriter.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java) lines 259-280):
+a `thrown(...)` call is rewritten to `SpecInternals.thrownImpl(this, inferredName, inferredType, <original args>)`,
+landing on ([`SpecInternals.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/runtime/SpecInternals.java) lines 74-98):
+
+```java
+public static Throwable checkExceptionThrown(Specification specification, Class<? extends Throwable> exceptionType) {
+  if (exceptionType == null) throw new InvalidSpecException("Thrown exception type cannot be inferred automatically. ...");
+  if (!Throwable.class.isAssignableFrom(exceptionType)) throw new InvalidSpecException("...");
+  Throwable actual = ((SpecificationContext) specification.getSpecificationContext()).getThrownException();
+  if (exceptionType.isInstance(actual)) return actual;
+  throw new WrongExceptionThrownError(exceptionType, actual);
+}
+```
+
+`notThrown`/`noExceptionThrown` are never rewritten to go through `SpecInternals` - their own bodies on
+`Specification` already do the equivalent check and throw `UnallowedExceptionThrownError`.
+
+**Validation**: at most one exception condition per `then`-block chain (`InvalidSpecCompileException` otherwise);
+must be a top-level statement.
+
+### Gap to Spockk
+
+- `FeatureRewriter.rewriteBehaviorStatements` (`spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt:143-165`)
+  handles `WHEN`/`SETUP`/`GIVEN` blocks identically - `irCallBlockEntered` / raw statements / `irCallBlockExited`,
+  no try/catch, no exception ever recorded anywhere.
+- `IrIdentifiers.kt` already declares `SPECIFICATION_FQN`, `SPECIFICATION_CONTEXT_FQN`, and `SPEC_INTERNALS_FQN` (the
+  last one currently unused anywhere), but no FQNs for `thrown`/`notThrown`/`noExceptionThrown` themselves, and
+  `IrSpecificationContext.kt` has no `setThrownException` wrapper.
+- Confirmed empirically (this session, `ExceptionConditionsSmokeTest.kt`): `thrown(Type::class.java)` always throws
+  `InvalidSpecException` (its fallback body); `when`-block exceptions always propagate raw, crashing the test before
+  the `then` block runs; `notThrown`/`noExceptionThrown` pass vacuously since `getThrownException()` is never
+  populated.
+
+### Proposed Approach
+
+**Kotlin simplification #1 - no AST type-inference needed for `thrown(Type)`.** `Specification.thrown(Class<T> type)`
+is an ordinary Java generic method; Kotlin infers `T` from the `Class<T>` argument on its own (ordinary generic
+inference, not Groovy's declaration-scanning trick). So the only rewrite needed is: replace the `thrown(Type::class.java)`
+call with `SpecInternals.checkExceptionThrown(this, Type::class.java)` - same argument expression, different (static)
+callee, plus a cast back from `Throwable` to the call's own already-resolved type via `irAs` (the exact pattern
+`IrSpecificationContext.getSpecificationContextInstance` already uses for a same-shaped cast, see
+`spockk-compiler-plugin/.../transformer/ir/IrSpecificationContext.kt`). This single substitution rule applies
+identically whether `thrown(...)` is a bare top-level statement or a `val e = thrown(...)` initializer - no
+special-casing between the two shapes, since both already carry the same resolved type before rewriting.
+
+`SpecInternals.checkExceptionThrown` is a **public static method already shaded unmodified into `spockk-core`** -
+zero new checking logic needs to be written; this also means edge cases (`thrown(null)` -> `InvalidSpecException`,
+non-`Throwable` class -> `InvalidSpecException`) are handled correctly for free, by construction.
+
+**Kotlin simplification #2 - `notThrown`/`noExceptionThrown` need no call-site rewriting at all.** Once the paired
+`when` block correctly populates `getThrownException()`, their real inherited bodies just work as-is.
+
+**Kotlin simplification #3 - no variable hoisting needed.** Spock's `moveVariableDeclarations` exists because Groovy
+source-level `try` blocks lexically scope their local variable declarations. Kotlin IR does not have this constraint:
+`IrVariable` references resolve by symbol identity, not lexical nesting, and this codebase already relies on exactly
+that fact - `CleanupBlockRewriter.rewrite()` (`spockk-compiler-plugin/.../transformer/fixture/CleanupBlockRewriter.kt:60-68`)
+wraps the **entire** feature body's statements (`behaviorStatements`, which routinely includes `when`-block variable
+declarations later read in `then`/`cleanup`) directly inside a `try` with zero hoisting step, and this already works
+correctly today. The new when-block wrapper follows the identical no-hoisting pattern.
+
+**When-block wrapping** (new `WhenBlockRewriter`, mirrors `CleanupBlockRewriter`'s use of the existing
+`irTry`/`irCatch`/`irCatchParameter` helpers from `spockk-compiler-plugin/.../compilation/ir/DeclarationIrBuilder.kt`):
+
+```
+specificationContext.setThrownException(null)     // new IrSpecificationContext.irSetThrownException
+callBlockEntered(...)
+try { <when-block statements, unchanged, no hoisting> }
+catch (t: Throwable) { specificationContext.setThrownException(t) }   // no rethrow - exception is consumed
+callBlockExited(...)
+```
+
+Gated on: the immediately-following `then` block contains a top-level exception-condition call. `FeatureBody.behaviorBlocks`
+is a flat, ordered `List<FeatureBlock>`, and `BlockOrderValidatingFeatureStatementsCollector`'s state machine
+guarantees a `WHEN` block is always immediately followed by exactly one `THEN` block (never `EXPECT` - `ACTION`
+state only accepts `AND`/`THEN`) - so `FeatureRewriter` can safely pre-scan `behaviorBlocks[i+1]` before its main
+loop, without restructuring the loop itself into anything more complex than an indexed pass.
+
+**`thrown(Type)` rewriting + validation** happens as a **new, separate, non-recursive pass** over a `THEN` block's
+own top-level statements - deliberately *not* folded into the existing `ConditionStatementsRewriter`
+(`spockk-compiler-plugin/.../transformer/condition/ConditionStatementsRewriter.kt`), which is shared/recursive
+machinery reused for `then`/`expect` blocks, `verify`/`verifyAll`/`verifyEach` lambda bodies, and helper methods -
+mixing in a then-block-only, non-recursive concern there would complicate an abstraction that today has no notion of
+"which block label is this" at all. Instead, `FeatureRewriter` runs the new pass on a `THEN` block's statements
+*before* handing the (now `thrown`-free) result to the existing, unmodified `ConditionRewriter`/`ConditionStatementsRewriter`
+pipeline - zero risk to the already-shipped `verify`/`verifyAll`/`verifyEach` feature. This pass:
+
+- Detects a top-level `thrown`/`notThrown`/`noExceptionThrown` call, as a bare statement *or* as a `val`/`var`
+  declaration's initializer (mirrors `ImplicitAssertionHelperCall.kt`'s FqName-matching technique, extended to also
+  look at `IrVariable.initializer`).
+- Rewrites a matched `thrown(Type::class.java)` call in place (substituting the statement, or the variable's
+  initializer) to `irAs(IrSpecInternals.irCheckExceptionThrown(...), originalCall.type)`.
+- Leaves `notThrown`/`noExceptionThrown` calls untouched (no rewrite needed, per simplification #2) - detection only
+  drives when-block-wrapping and validation.
+- Validates at most one exception-condition call per `then` block: `CompilationException` otherwise, via a new
+  `InvalidExceptionConditionExceptionFactory` mirroring the existing
+  `InvalidParametrizationExceptionFactory` (`spockk-compiler-plugin/.../transformer/parametrization/InvalidParametrizationExceptionFactory.kt`)
+  pattern (`CompilationException(message, file, irElement)`).
+
+A zero-arg `thrown()`/bare `notThrown` used in an `expect` block (or anywhere not the `then` half of a `when`/`then`
+pair) is **not** specially detected by this pass - it already falls through today to the real fallback body, which
+already throws the correct `InvalidSpecException` ("...only allowed in 'then' blocks..."). No new code needed for
+that case.
+
+### Scope (v1)
+
+**In scope:** when-block wrapping; `thrown(Type::class.java)` rewriting; `notThrown(Type::class.java)`/`noExceptionThrown()`
+working via wrapping alone; at-most-one-per-then-block validation; `expect`-block usage unchanged (already correct).
+
+**Deferred, documented as known limitations (not silent gaps):**
+
+- **Zero-arg `thrown()` with type inferred from a `val` declaration's static type.** Purely a Groovy ergonomic;
+  Kotlin's explicit `thrown(Type::class.java)` is the idiomatic, fully-supported spelling. A bare `thrown()` still
+  compiles (inherited real method, generic return type inferred by Kotlin) and still triggers when-block-wrapping
+  detection (harmless - the wrap just isn't exercised by a rewritten call), but the call itself isn't rewritten -
+  falls through to today's `InvalidSpecException` fallback, unchanged from current behavior.
+- **Chained `then` blocks** after one `when` (`when: ...` `then: ...` `then: ...`) - only the immediately-following
+  `then` block (`behaviorBlocks[i+1]`) is wrapped/validated. A second consecutive `then` block's exception-condition
+  call silently falls through to the fallback body.
+- **Fully general "must be top-level" diagnostics** (e.g. `thrown()` nested inside an `if`) - not specially detected;
+  falls through to today's fallback-throw behavior. Less precise error message than Spock's dedicated diagnostic, not
+  a functional regression.
+
+### Spock Source References
+
+- [`Specification.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/spock/lang/Specification.java) - `thrown`/`notThrown`/`noExceptionThrown` public API and fallback/real bodies
+- [`SpecInternals.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/runtime/SpecInternals.java) - `thrownImpl`/`checkExceptionThrown`, already shaded into `spockk-core`
+- [`SpecificationContext.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/runtime/SpecificationContext.java) - `getThrownException`/`setThrownException` (the latter not on `ISpecificationContext`, requires a cast to the concrete class - same pattern `IrSpecificationContext.kt` already uses for `setCurrentBlock`)
+- [`SpecRewriter.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java) - `rewriteWhenBlockForExceptionCondition`, its `visitThenBlock` call site
+- [`SpecialMethodCall.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java) / [`DeepBlockRewriter.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java) - exception-condition detection and `thrown` rewriting
+- [`WrongExceptionThrownError.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/runtime/WrongExceptionThrownError.java) / [`UnallowedExceptionThrownError.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/runtime/UnallowedExceptionThrownError.java) / [`InvalidSpecException.java`](https://github.com/spockframework/spock/blob/master/spock-core/src/main/java/org/spockframework/runtime/InvalidSpecException.java) - all `SpockAssertionError`/`SpockException` subclasses, already shaded
+- [`ExceptionConditions.groovy`](https://github.com/spockframework/spock/blob/master/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionConditions.groovy) - Spock's own test coverage (basic usage, wrong/inferred type, multiple exceptions, must-be-top-level, once-per-block)
+
+### Gap to Spockk (Existing Spockk Files Touched)
+
+- `spockk-compiler-plugin/.../ir/IrIdentifiers.kt` - new FQNs for `thrown`/`notThrown`/`noExceptionThrown`
+- `spockk-compiler-plugin/.../ir/IrStatement.kt` - `isExceptionConditionCall()` detector, mirroring `isAssertCall()`
+- `spockk-compiler-plugin/.../transformer/ir/IrSpecificationContext.kt` - new `irSetThrownException`
+- `spockk-compiler-plugin/.../transformer/ir/IrSpecInternals.kt` - new, wraps `SpecInternals.checkExceptionThrown`
+- `spockk-compiler-plugin/.../transformer/condition/WhenBlockRewriter.kt` - new, the when-block try/catch wrapper
+- `spockk-compiler-plugin/.../transformer/condition/ExceptionConditionRewriter.kt` - new, the then-block-scoped detection/rewrite/validation pass
+- `spockk-compiler-plugin/.../transformer/condition/InvalidExceptionConditionExceptionFactory.kt` - new, mirrors `InvalidParametrizationExceptionFactory`
+- `spockk-compiler-plugin/.../transformer/FeatureRewriter.kt` - pre-scan for WHEN/THEN pairing, route matching WHEN blocks through `WhenBlockRewriter`, run `ExceptionConditionRewriter` on matching THEN blocks before the existing `ConditionRewriter`
+- `spockk-specs/.../smoke/condition/ExceptionConditionsSmokeTest.kt` - flip pinned-broken-behavior assertions to real expected outcomes
+- New compilation snapshot test pairs under `spockk-specs/src/test/resources/samples/compilation/{source,transformed}/condition/`

--- a/_docs/specs/2026-08-09-exception-conditions-design.md
+++ b/_docs/specs/2026-08-09-exception-conditions-design.md
@@ -140,7 +140,12 @@ pipeline - zero risk to the already-shipped `verify`/`verifyAll`/`verifyEach` fe
   declaration's initializer (mirrors `ImplicitAssertionHelperCall.kt`'s FqName-matching technique, extended to also
   look at `IrVariable.initializer`).
 - Rewrites a matched `thrown(Type::class.java)` call in place (substituting the statement, or the variable's
-  initializer) to `irAs(IrSpecInternals.irCheckExceptionThrown(...), originalCall.type)`.
+  initializer) to `irAs(IrSpecInternals.irCheckExceptionThrown(...), originalCall.type)`. A zero-arg `thrown()`
+  assigned to a `val`/`var` (`val e: IOException = thrown()`) is rewritten the same way, synthesizing the missing
+  type argument as `DeclaredType::class.java` from the variable's own declared type - the same `KClass<T>.java`
+  idiom `MockingApiTransformer.inferMockType` already uses to infer `Mock()`/`Stub()`/`Spy()`'s type from a variable
+  declaration. A zero-arg `thrown()` used as a bare statement has no declared type to infer from and is left
+  unrewritten (see deferred scope below).
 - Leaves `notThrown`/`noExceptionThrown` calls untouched (no rewrite needed, per simplification #2) - detection only
   drives when-block-wrapping and validation.
 - Validates at most one exception-condition call per `then` block: `CompilationException` otherwise, via a new
@@ -155,16 +160,19 @@ that case.
 
 ### Scope (v1)
 
-**In scope:** when-block wrapping; `thrown(Type::class.java)` rewriting; `notThrown(Type::class.java)`/`noExceptionThrown()`
-working via wrapping alone; at-most-one-per-then-block validation; `expect`-block usage unchanged (already correct).
+**In scope:** when-block wrapping; `thrown(Type::class.java)` rewriting; zero-arg `thrown()` type inference from a
+`val`/`var` declaration's declared type; `notThrown(Type::class.java)`/`noExceptionThrown()` working via wrapping
+alone; at-most-one-per-then-block validation; `expect`-block usage unchanged (already correct).
 
 **Deferred, documented as known limitations (not silent gaps):**
 
-- **Zero-arg `thrown()` with type inferred from a `val` declaration's static type.** Purely a Groovy ergonomic;
-  Kotlin's explicit `thrown(Type::class.java)` is the idiomatic, fully-supported spelling. A bare `thrown()` still
-  compiles (inherited real method, generic return type inferred by Kotlin) and still triggers when-block-wrapping
-  detection (harmless - the wrap just isn't exercised by a rewritten call), but the call itself isn't rewritten -
-  falls through to today's `InvalidSpecException` fallback, unchanged from current behavior.
+- **Zero-arg `thrown()` used as a bare statement** (no `val`/`var` declaration to infer a type from, e.g.
+  `then { thrown() }`). Kotlin's explicit `thrown(Type::class.java)` is the idiomatic, fully-supported spelling for
+  this case. A bare `thrown()` still compiles (inherited real method, generic return type inferred by Kotlin as
+  `Nothing`/`Throwable`) and still triggers when-block-wrapping detection (harmless - the wrap just isn't exercised
+  by a rewritten call), but the call itself isn't rewritten - falls through to today's `InvalidSpecException`
+  fallback, unchanged from current behavior. (Assigning the result to a `val`/`var` first and using that, as in
+  `val e: IOException = thrown()`, is not affected by this limitation - see above.)
 - **Fully general "must be top-level" diagnostics** (e.g. `thrown()` nested inside an `if`, or passed as a function
   argument) - not specially detected; falls through to today's fallback-throw behavior (a bare `thrown()` throws
   `InvalidSpecException`; the preceding `when` block, having no top-level exception condition, isn't wrapped either,
@@ -194,7 +202,7 @@ initially scoped as a deferred limitation, but turn out not to be reachable at a
 - `spockk-compiler-plugin/.../transformer/ir/IrSpecificationContext.kt` - new `irSetThrownException`
 - `spockk-compiler-plugin/.../transformer/ir/IrSpecInternals.kt` - new, wraps `SpecInternals.checkExceptionThrown`
 - `spockk-compiler-plugin/.../transformer/condition/WhenBlockRewriter.kt` - new, the when-block try/catch wrapper
-- `spockk-compiler-plugin/.../transformer/condition/ExceptionConditionRewriter.kt` - new, the then-block-scoped detection/rewrite/validation pass
+- `spockk-compiler-plugin/.../transformer/condition/ExceptionConditionRewriter.kt` - new, the then-block-scoped detection/rewrite/validation pass, including zero-arg `thrown()` type inference for `val`/`var` declarations via the `KClass<T>.java` idiom shared with `MockingApiTransformer`
 - `spockk-compiler-plugin/.../transformer/condition/InvalidExceptionConditionExceptionFactory.kt` - new, mirrors `InvalidParametrizationExceptionFactory`
 - `spockk-compiler-plugin/.../transformer/FeatureRewriter.kt` - pre-scan for WHEN/THEN pairing, route matching WHEN blocks through `WhenBlockRewriter`, run `ExceptionConditionRewriter` on matching THEN blocks before the existing `ConditionRewriter`
 - `spockk-specs/.../smoke/condition/ExceptionConditionsSmokeTest.kt` - flip pinned-broken-behavior assertions to real expected outcomes

--- a/_docs/specs/2026-08-09-exception-conditions-design.md
+++ b/_docs/specs/2026-08-09-exception-conditions-design.md
@@ -165,12 +165,17 @@ working via wrapping alone; at-most-one-per-then-block validation; `expect`-bloc
   compiles (inherited real method, generic return type inferred by Kotlin) and still triggers when-block-wrapping
   detection (harmless - the wrap just isn't exercised by a rewritten call), but the call itself isn't rewritten -
   falls through to today's `InvalidSpecException` fallback, unchanged from current behavior.
-- **Chained `then` blocks** after one `when` (`when: ...` `then: ...` `then: ...`) - only the immediately-following
-  `then` block (`behaviorBlocks[i+1]`) is wrapped/validated. A second consecutive `then` block's exception-condition
-  call silently falls through to the fallback body.
-- **Fully general "must be top-level" diagnostics** (e.g. `thrown()` nested inside an `if`) - not specially detected;
-  falls through to today's fallback-throw behavior. Less precise error message than Spock's dedicated diagnostic, not
-  a functional regression.
+- **Fully general "must be top-level" diagnostics** (e.g. `thrown()` nested inside an `if`, or passed as a function
+  argument) - not specially detected; falls through to today's fallback-throw behavior (a bare `thrown()` throws
+  `InvalidSpecException`; the preceding `when` block, having no top-level exception condition, isn't wrapped either,
+  so the underlying exception - if any - propagates raw). Less precise error message than Spock's dedicated
+  diagnostic, not a functional regression: this degrades no worse than the pre-existing baseline.
+
+Chained `then` blocks after one `when` (`when: ...` `then: ...` `then: ...`, without an intervening `and`) were
+initially scoped as a deferred limitation, but turn out not to be reachable at all: Spockk's pre-existing
+`BlockOrderValidatingFeatureStatementsCollector` grammar already rejects a `then` block immediately following another
+`then` block as a compile error, unrelated to this feature - so `behaviorBlocks[i+1]` always being the correct paired
+`then` block for a `when` is not just an assumption, it's enforced upstream.
 
 ### Spock Source References
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.java.installations.fromEnv=JDK21
 org.gradle.jvmargs=-Xmx2g "-XX:MaxMetaspaceSize=1g"
 kotlin.daemon.jvmargs=-Xmx1g
 group=io.github.pshevche.spockk
-version=0.5.1
+version=0.6.0

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrIdentifiers.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrIdentifiers.kt
@@ -31,6 +31,9 @@ internal object IrIdentifiers {
     val SPECIFICATION_FQN = LANG_PKG_FQN.child("Specification")
     val WILDCARD_FQN = SPECIFICATION_FQN.child("_")
     val SHARED_ANNOTATION_FQN = LANG_PKG_FQN.child("Shared")
+    val THROWN_FQN = SPECIFICATION_FQN.child("thrown")
+    val NOT_THROWN_FQN = SPECIFICATION_FQN.child("notThrown")
+    val NO_EXCEPTION_THROWN_FQN = SPECIFICATION_FQN.child("noExceptionThrown")
 
     private val RUNTIME_PKG_FQN = FqName("org.spockframework.runtime")
     val ERROR_COLLECTOR_FQN = RUNTIME_PKG_FQN.child("ErrorCollector")

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrStatement.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrStatement.kt
@@ -101,3 +101,19 @@ internal fun IrStatement.isAssertCall(): Boolean {
   val owner = (this as? IrCall)?.symbol?.owner ?: return false
   return owner.fqNameWhenAvailable == IrIdentifiers.Kotlin.ASSERT_FQN
 }
+
+private val EXCEPTION_CONDITION_FQNS = setOf(
+  IrIdentifiers.Spock.THROWN_FQN,
+  IrIdentifiers.Spock.NOT_THROWN_FQN,
+  IrIdentifiers.Spock.NO_EXCEPTION_THROWN_FQN
+)
+
+internal fun IrStatement.isExceptionConditionCall(): Boolean {
+  val owner = (this as? IrCall)?.symbol?.owner ?: return false
+  return owner.fqNameWhenAvailable in EXCEPTION_CONDITION_FQNS
+}
+
+internal fun IrStatement.isThrownCall(): Boolean {
+  val owner = (this as? IrCall)?.symbol?.owner ?: return false
+  return owner.fqNameWhenAvailable == IrIdentifiers.Spock.THROWN_FQN
+}

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrStatement.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrStatement.kt
@@ -22,16 +22,19 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetObjectValue
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperator.IMPLICIT_COERCION_TO_UNIT
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.isFakeOverride
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.name.FqName
 
@@ -108,12 +111,32 @@ private val EXCEPTION_CONDITION_FQNS = setOf(
   IrIdentifiers.Spock.NO_EXCEPTION_THROWN_FQN
 )
 
-internal fun IrStatement.isExceptionConditionCall(): Boolean {
-  val owner = (this as? IrCall)?.symbol?.owner ?: return false
-  return owner.fqNameWhenAvailable in EXCEPTION_CONDITION_FQNS
+// thrown/notThrown/noExceptionThrown are inherited from spock.lang.Specification, so a call site
+// resolves to a [fake_override] declared in the user's spec subclass, whose own fqNameWhenAvailable
+// points at the subclass, not Specification - unwrap to the real declaration before comparing.
+private tailrec fun IrSimpleFunction.originalDeclaration(): IrSimpleFunction {
+  if (!isFakeOverride) return this
+  val overridden = overriddenSymbols.firstOrNull()?.owner ?: return this
+  return overridden.originalDeclaration()
 }
 
-internal fun IrStatement.isThrownCall(): Boolean {
-  val owner = (this as? IrCall)?.symbol?.owner ?: return false
-  return owner.fqNameWhenAvailable == IrIdentifiers.Spock.THROWN_FQN
+// A bare top-level call with a non-Unit return type is wrapped in an implicit-coercion-to-Unit
+// type operator (mirroring isConditionStatement's use of unwrapImplicitCoercionToUnit for the same
+// reason); a val/var initializer assigning a flexibly-nullable Java generic return (like
+// Specification.thrown<T>()'s T) to a non-null declared type is instead wrapped in an
+// implicit-notnull type operator. Unwrap through either before attempting to recognize the call.
+private tailrec fun IrExpression.unwrapForExceptionConditionDetection(): IrExpression {
+  val operatorCall = this as? IrTypeOperatorCall ?: return this
+  return when (operatorCall.operator) {
+    IMPLICIT_COERCION_TO_UNIT, IrTypeOperator.IMPLICIT_NOTNULL -> operatorCall.argument.unwrapForExceptionConditionDetection()
+    else -> this
+  }
 }
+
+internal fun IrStatement.asExceptionConditionCall(): IrCall? {
+  val call = (this as? IrExpression)?.unwrapForExceptionConditionDetection() as? IrCall ?: return null
+  return call.takeIf { it.symbol.owner.originalDeclaration().fqNameWhenAvailable in EXCEPTION_CONDITION_FQNS }
+}
+
+internal fun IrCall.isThrownCall(): Boolean =
+  symbol.owner.originalDeclaration().fqNameWhenAvailable == IrIdentifiers.Spock.THROWN_FQN

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrStatement.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrStatement.kt
@@ -120,11 +120,9 @@ private tailrec fun IrSimpleFunction.originalDeclaration(): IrSimpleFunction {
   return overridden.originalDeclaration()
 }
 
-// A bare top-level call with a non-Unit return type is wrapped in an implicit-coercion-to-Unit
-// type operator (mirroring isConditionStatement's use of unwrapImplicitCoercionToUnit for the same
-// reason); a val/var initializer assigning a flexibly-nullable Java generic return (like
-// Specification.thrown<T>()'s T) to a non-null declared type is instead wrapped in an
-// implicit-notnull type operator. Unwrap through either before attempting to recognize the call.
+// A bare non-Unit-typed statement gets an implicit-coercion-to-Unit wrapper; a val/var initializer
+// assigning thrown<T>()'s flexibly-nullable Java generic return to a non-null type gets an
+// implicit-notnull wrapper instead. Unwrap through either before recognizing the call.
 private tailrec fun IrExpression.unwrapForExceptionConditionDetection(): IrExpression {
   val operatorCall = this as? IrTypeOperatorCall ?: return this
   return when (operatorCall.operator) {

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
@@ -145,8 +145,8 @@ internal class FeatureRewriter(override val rewriterContext: SpockkIrRewriterCon
     addAll(featureBody.anonymousStatements)
     val behaviorBlocks = featureBody.behaviorBlocks
     behaviorBlocks.forEachIndexed { index, it ->
-      when(it.element.label) {
-        FeatureBlockLabel.THEN->{
+      when (it.element.label) {
+        FeatureBlockLabel.THEN -> {
           // A WHEN block is always immediately followed by exactly one THEN block (enforced at
           // collection time), so an exception condition found here was already used to decide
           // whether the preceding WHEN block needed WhenBlockRewriter below.
@@ -155,15 +155,18 @@ internal class FeatureRewriter(override val rewriterContext: SpockkIrRewriterCon
             ConditionRewriter(rewriterContext, builder, feature, it.ordinal, valueRecorderVar, errorCollectorVar)
           addAll(conditionRewriter.rewrite(statements))
         }
-        FeatureBlockLabel.EXPECT->{
+
+        FeatureBlockLabel.EXPECT -> {
           val conditionRewriter =
             ConditionRewriter(rewriterContext, builder, feature, it.ordinal, valueRecorderVar, errorCollectorVar)
           addAll(conditionRewriter.rewrite(it.statements))
         }
-        FeatureBlockLabel.WHEN if behaviorBlocks.getOrNull(index + 1)?.statements?.hasExceptionCondition() == true->{
+
+        FeatureBlockLabel.WHEN if behaviorBlocks.getOrNull(index + 1)?.statements?.hasExceptionCondition() == true -> {
           addAll(WhenBlockRewriter(rewriterContext, feature, it).rewrite())
         }
-        else->{
+
+        else -> {
           add(
             rewriterContext.spockRuntime.irCallBlockEntered(
               builder,

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
@@ -30,7 +30,10 @@ import io.github.pshevche.spockk.compilation.shared.FeatureBlockLabel
 import io.github.pshevche.spockk.compilation.shared.FeatureBody
 import io.github.pshevche.spockk.compilation.shared.SpockkTransformationContext.FeatureContext
 import io.github.pshevche.spockk.compilation.transformer.condition.ConditionRewriter
+import io.github.pshevche.spockk.compilation.transformer.condition.ExceptionConditionRewriter
+import io.github.pshevche.spockk.compilation.transformer.condition.WhenBlockRewriter
 import io.github.pshevche.spockk.compilation.transformer.condition.containsImplicitAssertionHelperCall
+import io.github.pshevche.spockk.compilation.transformer.condition.hasExceptionCondition
 import io.github.pshevche.spockk.compilation.transformer.condition.irStaticErrorCollectorDeclaration
 import io.github.pshevche.spockk.compilation.transformer.condition.irValueRecorderDeclaration
 import io.github.pshevche.spockk.compilation.transformer.condition.isConditionStatement
@@ -140,27 +143,47 @@ internal class FeatureRewriter(override val rewriterContext: SpockkIrRewriterCon
       if (hasConditions) irStaticErrorCollectorDeclaration(builder, feature).also { add(it) } else null
 
     addAll(featureBody.anonymousStatements)
-    featureBody.behaviorBlocks.forEach {
-      if (it.element.label == FeatureBlockLabel.EXPECT || it.element.label == FeatureBlockLabel.THEN) {
-        val conditionRewriter =
-          ConditionRewriter(rewriterContext, builder, feature, it.ordinal, valueRecorderVar, errorCollectorVar)
-        addAll(conditionRewriter.rewrite(it.statements))
-      } else {
-        add(
-          rewriterContext.spockRuntime.irCallBlockEntered(
-            builder,
-            feature.requiredThisParameter(),
-            it.ordinal
+    val behaviorBlocks = featureBody.behaviorBlocks
+    behaviorBlocks.forEachIndexed { index, it ->
+      when {
+        it.element.label == FeatureBlockLabel.THEN -> {
+          // A WHEN block is always immediately followed by exactly one THEN block (enforced at
+          // collection time), so an exception condition found here was already used to decide
+          // whether the preceding WHEN block needed WhenBlockRewriter below.
+          val statements = ExceptionConditionRewriter(rewriterContext, feature).rewrite(it.statements)
+          val conditionRewriter =
+            ConditionRewriter(rewriterContext, builder, feature, it.ordinal, valueRecorderVar, errorCollectorVar)
+          addAll(conditionRewriter.rewrite(statements))
+        }
+
+        it.element.label == FeatureBlockLabel.EXPECT -> {
+          val conditionRewriter =
+            ConditionRewriter(rewriterContext, builder, feature, it.ordinal, valueRecorderVar, errorCollectorVar)
+          addAll(conditionRewriter.rewrite(it.statements))
+        }
+
+        it.element.label == FeatureBlockLabel.WHEN &&
+          behaviorBlocks.getOrNull(index + 1)?.statements?.hasExceptionCondition() == true -> {
+          addAll(WhenBlockRewriter(rewriterContext, feature, it).rewrite())
+        }
+
+        else -> {
+          add(
+            rewriterContext.spockRuntime.irCallBlockEntered(
+              builder,
+              feature.requiredThisParameter(),
+              it.ordinal
+            )
           )
-        )
-        addAll(it.statements)
-        add(
-          rewriterContext.spockRuntime.irCallBlockExited(
-            builder,
-            feature.requiredThisParameter(),
-            it.ordinal
+          addAll(it.statements)
+          add(
+            rewriterContext.spockRuntime.irCallBlockExited(
+              builder,
+              feature.requiredThisParameter(),
+              it.ordinal
+            )
           )
-        )
+        }
       }
     }
   }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/FeatureRewriter.kt
@@ -145,8 +145,8 @@ internal class FeatureRewriter(override val rewriterContext: SpockkIrRewriterCon
     addAll(featureBody.anonymousStatements)
     val behaviorBlocks = featureBody.behaviorBlocks
     behaviorBlocks.forEachIndexed { index, it ->
-      when {
-        it.element.label == FeatureBlockLabel.THEN -> {
+      when(it.element.label) {
+        FeatureBlockLabel.THEN->{
           // A WHEN block is always immediately followed by exactly one THEN block (enforced at
           // collection time), so an exception condition found here was already used to decide
           // whether the preceding WHEN block needed WhenBlockRewriter below.
@@ -155,19 +155,15 @@ internal class FeatureRewriter(override val rewriterContext: SpockkIrRewriterCon
             ConditionRewriter(rewriterContext, builder, feature, it.ordinal, valueRecorderVar, errorCollectorVar)
           addAll(conditionRewriter.rewrite(statements))
         }
-
-        it.element.label == FeatureBlockLabel.EXPECT -> {
+        FeatureBlockLabel.EXPECT->{
           val conditionRewriter =
             ConditionRewriter(rewriterContext, builder, feature, it.ordinal, valueRecorderVar, errorCollectorVar)
           addAll(conditionRewriter.rewrite(it.statements))
         }
-
-        it.element.label == FeatureBlockLabel.WHEN &&
-          behaviorBlocks.getOrNull(index + 1)?.statements?.hasExceptionCondition() == true -> {
+        FeatureBlockLabel.WHEN if behaviorBlocks.getOrNull(index + 1)?.statements?.hasExceptionCondition() == true->{
           addAll(WhenBlockRewriter(rewriterContext, feature, it).rewrite())
         }
-
-        else -> {
+        else->{
           add(
             rewriterContext.spockRuntime.irCallBlockEntered(
               builder,

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/InternalIdentifiers.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/InternalIdentifiers.kt
@@ -28,6 +28,7 @@ internal object InternalIdentifiers {
   val VALUE_RECORDER_VAR = Name.identifier($$"$spock_valueRecorder")
   val VERIFY_ALL_ERROR_COLLECTOR_VAR = Name.identifier($$"$spock_verifyAllErrorCollector")
   val CONDITION_THROWABLE_VAR = Name.identifier($$"$spock_condition_throwable")
+  val WHEN_BLOCK_THROWABLE_VAR = Name.identifier($$"$spock_when_throwable")
 
   fun getFeatureName(context: FeatureContext): String =
     $$"$spock_feature_$${context.specDepth}_$${context.ordinal}"

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionCall.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionCall.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.transformer.condition
+
+import io.github.pshevche.spockk.compilation.ir.isExceptionConditionCall
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrCall
+
+/**
+ * A top-level `thrown`/`notThrown`/`noExceptionThrown` call found in a `then` block's own
+ * statement list - either a bare statement, or the initializer of a `val`/`var` declaration
+ * (`val e = thrown(...)`).
+ */
+internal sealed class ExceptionConditionOccurrence(val call: IrCall) {
+  internal class BareStatement(call: IrCall) : ExceptionConditionOccurrence(call)
+  internal class VariableInitializer(val variable: IrVariable, call: IrCall) : ExceptionConditionOccurrence(call)
+}
+
+internal fun List<IrStatement>.findExceptionConditionOccurrences(): List<ExceptionConditionOccurrence> =
+  mapNotNull { statement ->
+    when {
+      statement.isExceptionConditionCall() -> ExceptionConditionOccurrence.BareStatement(statement as IrCall)
+      statement is IrVariable && statement.initializer?.isExceptionConditionCall() == true ->
+        ExceptionConditionOccurrence.VariableInitializer(statement, statement.initializer as IrCall)
+      else -> null
+    }
+  }
+
+internal fun List<IrStatement>.hasExceptionCondition(): Boolean = findExceptionConditionOccurrences().isNotEmpty()

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionCall.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionCall.kt
@@ -14,7 +14,7 @@
 
 package io.github.pshevche.spockk.compilation.transformer.condition
 
-import io.github.pshevche.spockk.compilation.ir.isExceptionConditionCall
+import io.github.pshevche.spockk.compilation.ir.asExceptionConditionCall
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrCall
@@ -22,19 +22,26 @@ import org.jetbrains.kotlin.ir.expressions.IrCall
 /**
  * A top-level `thrown`/`notThrown`/`noExceptionThrown` call found in a `then` block's own
  * statement list - either a bare statement, or the initializer of a `val`/`var` declaration
- * (`val e = thrown(...)`).
+ * (`val e = thrown(...)`). [call] is the unwrapped call (see
+ * [io.github.pshevche.spockk.compilation.ir.asExceptionConditionCall]) usable for classifying and
+ * rewriting; [BareStatement.statement] is the original (possibly coercion-wrapped) list entry,
+ * needed to find and replace it in place.
  */
 internal sealed class ExceptionConditionOccurrence(val call: IrCall) {
-  internal class BareStatement(call: IrCall) : ExceptionConditionOccurrence(call)
+  internal class BareStatement(val statement: IrStatement, call: IrCall) : ExceptionConditionOccurrence(call)
   internal class VariableInitializer(val variable: IrVariable, call: IrCall) : ExceptionConditionOccurrence(call)
 }
 
 internal fun List<IrStatement>.findExceptionConditionOccurrences(): List<ExceptionConditionOccurrence> =
   mapNotNull { statement ->
+    val bareCall = statement.asExceptionConditionCall()
+    val initializerCall = (statement as? IrVariable)?.initializer?.asExceptionConditionCall()
     when {
-      statement.isExceptionConditionCall() -> ExceptionConditionOccurrence.BareStatement(statement as IrCall)
-      statement is IrVariable && statement.initializer?.isExceptionConditionCall() == true ->
-        ExceptionConditionOccurrence.VariableInitializer(statement, statement.initializer as IrCall)
+      bareCall != null -> ExceptionConditionOccurrence.BareStatement(statement, bareCall)
+
+      statement is IrVariable && initializerCall != null ->
+        ExceptionConditionOccurrence.VariableInitializer(statement, initializerCall)
+
       else -> null
     }
   }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
@@ -18,9 +18,14 @@ import io.github.pshevche.spockk.compilation.ir.isThrownCall
 import io.github.pshevche.spockk.compilation.ir.requiredThisParameter
 import io.github.pshevche.spockk.compilation.transformer.SpockkIrRewriter
 import io.github.pshevche.spockk.compilation.transformer.ir.SpockkIrRewriterContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irAs
 import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
+import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.util.file
 
 /**
@@ -68,7 +73,11 @@ internal class ExceptionConditionRewriter(
       is ExceptionConditionOccurrence.BareStatement -> {
         // Discarded value: nullability doesn't matter, cast to the original call's own type.
         val castCall = builder.irAs(rewrittenCall, occurrence.call.type)
-        statements.map { if (it === occurrence.statement) castCall else it }
+        // thrown()'s non-Unit result, used as a bare statement, was coercion-wrapped by the
+        // Kotlin frontend before this rewrite ever saw it - preserve that shape so the rewritten
+        // statement looks exactly as ordinary Kotlin source producing the same call would.
+        val replacement = if (occurrence.statement.isCoercedToUnit()) builder.irCoerceToUnit(castCall) else castCall
+        statements.map { if (it === occurrence.statement) replacement else it }
       }
 
       is ExceptionConditionOccurrence.VariableInitializer -> {
@@ -80,3 +89,16 @@ internal class ExceptionConditionRewriter(
     }
   }
 }
+
+private fun IrStatement.isCoercedToUnit(): Boolean =
+  this is IrTypeOperatorCall && operator == IrTypeOperator.IMPLICIT_COERCION_TO_UNIT
+
+private fun DeclarationIrBuilder.irCoerceToUnit(value: IrExpression): IrExpression =
+  IrTypeOperatorCallImpl(
+    startOffset,
+    endOffset,
+    context.irBuiltIns.unitType,
+    IrTypeOperator.IMPLICIT_COERCION_TO_UNIT,
+    context.irBuiltIns.unitType,
+    value
+  )

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
@@ -14,18 +14,24 @@
 
 package io.github.pshevche.spockk.compilation.transformer.condition
 
+import io.github.pshevche.spockk.compilation.ir.IrIdentifiers
+import io.github.pshevche.spockk.compilation.ir.findPropertyGetter
 import io.github.pshevche.spockk.compilation.ir.isThrownCall
 import io.github.pshevche.spockk.compilation.ir.requiredThisParameter
 import io.github.pshevche.spockk.compilation.transformer.SpockkIrRewriter
 import io.github.pshevche.spockk.compilation.transformer.ir.SpockkIrRewriterContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.backend.jvm.ir.kClassReference
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irAs
+import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.file
 
 /**
@@ -39,8 +45,10 @@ import org.jetbrains.kotlin.ir.util.file
  * unchanged - including its handling of `thrown(null)` and non-`Throwable` types. `notThrown`/
  * `noExceptionThrown` are left untouched: their inherited bodies on `Specification` already read
  * the exception [WhenBlockRewriter] records correctly, with no rewrite needed. A zero-arg
- * `thrown()` is detected (for when-block-wrapping and validation purposes) but not rewritten - see
- * the design doc's deferred scope.
+ * `thrown()` assigned to a `val`/`var` infers its exception type from the declaration's own
+ * declared type (`val e: IOException = thrown()`); a zero-arg `thrown()` used as a bare statement
+ * has no declared type to infer from and is left unrewritten - see the design doc's deferred
+ * scope.
  */
 internal class ExceptionConditionRewriter(
   override val rewriterContext: SpockkIrRewriterContext,
@@ -48,6 +56,8 @@ internal class ExceptionConditionRewriter(
 ) : SpockkIrRewriter {
 
   private val builder = irBuilder(feature.symbol)
+  private val kClassJavaPropGetter =
+    rewriterContext.findPropertyGetter(IrIdentifiers.Kotlin.KCLASS_JAVA_CALLABLE_ID)
 
   fun rewrite(statements: List<IrStatement>): List<IrStatement> {
     val occurrences = statements.findExceptionConditionOccurrences()
@@ -59,9 +69,11 @@ internal class ExceptionConditionRewriter(
     val occurrence = occurrences.singleOrNull() ?: return statements
     if (!occurrence.call.isThrownCall()) return statements
 
-    // Zero-arg `thrown()`: not rewritten, falls through to its real (unconditionally throwing)
-    // fallback body - see design doc's deferred scope.
-    val exceptionTypeArg = occurrence.call.arguments.getOrNull(1) ?: return statements
+    // Zero-arg `thrown()` as a bare statement: not rewritten, falls through to its real
+    // (unconditionally throwing) fallback body - see design doc's deferred scope.
+    val exceptionTypeArg = occurrence.call.arguments.getOrNull(1)
+      ?: occurrence.inferredExceptionTypeArg()
+      ?: return statements
 
     val rewrittenCall = rewriterContext.specInternals.irCheckExceptionThrown(
       builder,
@@ -86,6 +98,18 @@ internal class ExceptionConditionRewriter(
         occurrence.variable.initializer = builder.irAs(rewrittenCall, occurrence.variable.type)
         statements
       }
+    }
+  }
+
+  // Synthesizes `Type::class.java` from a `val`/`var` declaration's own declared type, the same
+  // `KClass<T>.java` idiom MockingApiTransformer.inferMockType uses. Null for a bare statement
+  // (no declared type) or a non-class declared type.
+  private fun ExceptionConditionOccurrence.inferredExceptionTypeArg(): IrExpression? {
+    val variable = (this as? ExceptionConditionOccurrence.VariableInitializer)?.variable ?: return null
+    val declaredTypeClass = variable.type.classOrNull ?: return null
+    return builder.irCall(kClassJavaPropGetter.symbol, variable.type).apply {
+      arguments.clear()
+      arguments.add(builder.kClassReference(declaredTypeClass.defaultType))
     }
   }
 }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
@@ -63,12 +63,18 @@ internal class ExceptionConditionRewriter(
       feature.requiredThisParameter(),
       exceptionTypeArg
     )
-    val castCall = builder.irAs(rewrittenCall, occurrence.call.type)
 
     return when (occurrence) {
-      is ExceptionConditionOccurrence.BareStatement -> statements.map { if (it === occurrence.call) castCall else it }
+      is ExceptionConditionOccurrence.BareStatement -> {
+        // Discarded value: nullability doesn't matter, cast to the original call's own type.
+        val castCall = builder.irAs(rewrittenCall, occurrence.call.type)
+        statements.map { if (it === occurrence.statement) castCall else it }
+      }
+
       is ExceptionConditionOccurrence.VariableInitializer -> {
-        occurrence.variable.initializer = castCall
+        // Cast to the variable's declared type (not the unwrapped call's flexibly-nullable type),
+        // preserving whatever non-null assertion the original initializer had.
+        occurrence.variable.initializer = builder.irAs(rewrittenCall, occurrence.variable.type)
         statements
       }
     }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/ExceptionConditionRewriter.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.transformer.condition
+
+import io.github.pshevche.spockk.compilation.ir.isThrownCall
+import io.github.pshevche.spockk.compilation.ir.requiredThisParameter
+import io.github.pshevche.spockk.compilation.transformer.SpockkIrRewriter
+import io.github.pshevche.spockk.compilation.transformer.ir.SpockkIrRewriterContext
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irAs
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.util.file
+
+/**
+ * Detects and rewrites top-level `thrown`/`notThrown`/`noExceptionThrown` calls in a `then`
+ * block's own statement list. Deliberately separate from [ConditionStatementsRewriter], which is
+ * shared/recursive machinery for ordinary conditions and `verify`/`verifyAll`/`verifyEach` -
+ * exception conditions are then-block-only and never recurse into nested lambdas.
+ *
+ * `thrown(Type::class.java)` is rewritten to call Spock's own `SpecInternals.checkExceptionThrown`
+ * (already shaded into `spockk-core`), reusing its exception-matching/error-selection logic
+ * unchanged - including its handling of `thrown(null)` and non-`Throwable` types. `notThrown`/
+ * `noExceptionThrown` are left untouched: their inherited bodies on `Specification` already read
+ * the exception [WhenBlockRewriter] records correctly, with no rewrite needed. A zero-arg
+ * `thrown()` is detected (for when-block-wrapping and validation purposes) but not rewritten - see
+ * the design doc's deferred scope.
+ */
+internal class ExceptionConditionRewriter(
+  override val rewriterContext: SpockkIrRewriterContext,
+  private val feature: IrFunction
+) : SpockkIrRewriter {
+
+  private val builder = irBuilder(feature.symbol)
+
+  fun rewrite(statements: List<IrStatement>): List<IrStatement> {
+    val occurrences = statements.findExceptionConditionOccurrences()
+    if (occurrences.size > 1) {
+      throw InvalidExceptionConditionExceptionFactory(feature.file, occurrences[1].call)
+        .multipleExceptionConditionsException()
+    }
+
+    val occurrence = occurrences.singleOrNull() ?: return statements
+    if (!occurrence.call.isThrownCall()) return statements
+
+    // Zero-arg `thrown()`: not rewritten, falls through to its real (unconditionally throwing)
+    // fallback body - see design doc's deferred scope.
+    val exceptionTypeArg = occurrence.call.arguments.getOrNull(1) ?: return statements
+
+    val rewrittenCall = rewriterContext.specInternals.irCheckExceptionThrown(
+      builder,
+      feature.requiredThisParameter(),
+      exceptionTypeArg
+    )
+    val castCall = builder.irAs(rewrittenCall, occurrence.call.type)
+
+    return when (occurrence) {
+      is ExceptionConditionOccurrence.BareStatement -> statements.map { if (it === occurrence.call) castCall else it }
+      is ExceptionConditionOccurrence.VariableInitializer -> {
+        occurrence.variable.initializer = castCall
+        statements
+      }
+    }
+  }
+}

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/InvalidExceptionConditionExceptionFactory.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/InvalidExceptionConditionExceptionFactory.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.transformer.condition
+
+import org.jetbrains.kotlin.backend.common.CompilationException
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrFile
+
+internal class InvalidExceptionConditionExceptionFactory(
+  private val file: IrFile,
+  private val thenBlockIr: IrElement
+) {
+
+  fun multipleExceptionConditionsException() =
+    CompilationException(
+      "A 'then' block may only have a single exception condition",
+      file,
+      thenBlockIr
+    )
+}

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/WhenBlockRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/WhenBlockRewriter.kt
@@ -25,6 +25,7 @@ import io.github.pshevche.spockk.compilation.transformer.ir.SpockkIrRewriterCont
 import io.github.pshevche.spockk.compilation.transformer.ir.getSpecificationContext
 import org.jetbrains.kotlin.backend.common.lower.irCatch
 import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irNull
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -69,7 +70,7 @@ internal class WhenBlockRewriter(
 
     return builder.irTry(
       tryExpressions = whenBlock.statements,
-      catchExpressions = listOf(builder.irCatch(catchVar, catchResult)),
+      catchExpressions = listOf(builder.irCatch(catchVar, builder.irBlock { +catchResult })),
       finallyExpressions = listOf()
     )
   }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/WhenBlockRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/condition/WhenBlockRewriter.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.transformer.condition
+
+import io.github.pshevche.spockk.compilation.ir.irCatchParameter
+import io.github.pshevche.spockk.compilation.ir.irTry
+import io.github.pshevche.spockk.compilation.ir.requiredThisParameter
+import io.github.pshevche.spockk.compilation.shared.FeatureBlock
+import io.github.pshevche.spockk.compilation.transformer.InternalIdentifiers.WHEN_BLOCK_THROWABLE_VAR
+import io.github.pshevche.spockk.compilation.transformer.SpockkIrRewriter
+import io.github.pshevche.spockk.compilation.transformer.ir.IrSpecificationContext
+import io.github.pshevche.spockk.compilation.transformer.ir.SpockkIrRewriterContext
+import io.github.pshevche.spockk.compilation.transformer.ir.getSpecificationContext
+import org.jetbrains.kotlin.backend.common.lower.irCatch
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irNull
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.util.parentAsClass
+
+/**
+ * Rewrites a `when` block paired with a `then` block that contains a `thrown`/`notThrown`/
+ * `noExceptionThrown` call: wraps the block's statements in a try/catch that records any thrown
+ * exception on `SpecificationContext`, mirroring Spock's own
+ * `SpecRewriter.rewriteWhenBlockForExceptionCondition`. No variable-declaration hoisting is
+ * needed here (unlike Spock's Groovy-source-scoping workaround) - Kotlin IR resolves locals by
+ * symbol, not lexical nesting, the same fact [io.github.pshevche.spockk.compilation.transformer.fixture.CleanupBlockRewriter]
+ * already relies on when it wraps the entire feature body's statements in a try.
+ */
+internal class WhenBlockRewriter(
+  override val rewriterContext: SpockkIrRewriterContext,
+  private val feature: IrFunction,
+  private val whenBlock: FeatureBlock
+) : SpockkIrRewriter {
+
+  private val builder = irBuilder(feature.symbol)
+
+  fun rewrite(): List<IrStatement> {
+    val specAccessor = feature.requiredThisParameter()
+    val specificationContext = feature.parentAsClass.getSpecificationContext(rewriterContext)
+
+    return buildList {
+      add(specificationContext.irSetThrownException(builder, specAccessor, builder.irNull()))
+      add(rewriterContext.spockRuntime.irCallBlockEntered(builder, specAccessor, whenBlock.ordinal))
+      add(wrapInTryCatch(specAccessor, specificationContext))
+      add(rewriterContext.spockRuntime.irCallBlockExited(builder, specAccessor, whenBlock.ordinal))
+    }
+  }
+
+  private fun wrapInTryCatch(
+    specAccessor: IrValueParameter,
+    specificationContext: IrSpecificationContext
+  ): IrStatement {
+    val catchVar = irCatchParameter(WHEN_BLOCK_THROWABLE_VAR, irBuiltIns.throwableType).apply { parent = feature }
+    val catchResult = specificationContext.irSetThrownException(builder, specAccessor, builder.irGet(catchVar))
+
+    return builder.irTry(
+      tryExpressions = whenBlock.statements,
+      catchExpressions = listOf(builder.irCatch(catchVar, catchResult)),
+      finallyExpressions = listOf()
+    )
+  }
+}

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/ir/IrSpecInternals.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/ir/IrSpecInternals.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.transformer.ir
+
+import io.github.pshevche.spockk.compilation.ir.IrIdentifiers.Spock.SPEC_INTERNALS_FQN
+import io.github.pshevche.spockk.compilation.ir.findRequiredClassSymbol
+import org.jetbrains.kotlin.backend.jvm.functionByName
+import org.jetbrains.kotlin.ir.builders.IrBuilder
+import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+
+/**
+ * Wraps `org.spockframework.runtime.SpecInternals`, a real Spock class shaded unmodified into
+ * `spockk-core`, so `thrown(Type)` can reuse its `checkExceptionThrown` logic instead of
+ * reimplementing exception-type matching and error selection.
+ */
+internal class IrSpecInternals private constructor(
+  private val specInternalsClassSymbol: IrClassSymbol
+) {
+
+  fun irCheckExceptionThrown(
+    builder: IrBuilder,
+    specAccessor: IrValueParameter,
+    exceptionTypeExpr: IrExpression
+  ): IrCall {
+    val checkExceptionThrown = specInternalsClassSymbol.functionByName("checkExceptionThrown")
+    return with(builder) {
+      irCall(checkExceptionThrown).apply {
+        arguments[0] = irGet(specAccessor)
+        arguments[1] = exceptionTypeExpr
+      }
+    }
+  }
+
+  companion object {
+    fun create(generatorContext: IrGeneratorContext): IrSpecInternals {
+      val specInternalsClass = generatorContext.findRequiredClassSymbol(SPEC_INTERNALS_FQN)
+      return IrSpecInternals(specInternalsClass)
+    }
+  }
+}

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/ir/IrSpecificationContext.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/ir/IrSpecificationContext.kt
@@ -61,6 +61,17 @@ internal class IrSpecificationContext(
     }
   }
 
+  fun irSetThrownException(builder: IrBuilder, specAccessor: IrValueParameter, exceptionExpr: IrExpression): IrExpression {
+    val specificationContextInstance = getSpecificationContextInstance(builder, specAccessor)
+    val setThrownException = specificationContextClass.functionByName("setThrownException")
+    return with(builder) {
+      irCall(setThrownException).apply {
+        dispatchReceiver = specificationContextInstance
+        arguments[1] = exceptionExpr
+      }
+    }
+  }
+
   fun irGetSharedInstance(
     builder: IrBuilder,
     specAccessor: IrValueParameter

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/ir/SpockkIrRewriterContext.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/ir/SpockkIrRewriterContext.kt
@@ -22,5 +22,6 @@ import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
 internal class SpockkIrRewriterContext(
   private val defaultGenerator: IrGeneratorContext,
   val sourceTextCache: SourceTextCache = SourceTextCache(),
-  val spockRuntime: IrSpockRuntime = IrSpockRuntime.create(defaultGenerator, sourceTextCache)
+  val spockRuntime: IrSpockRuntime = IrSpockRuntime.create(defaultGenerator, sourceTextCache),
+  val specInternals: IrSpecInternals = IrSpecInternals.create(defaultGenerator)
 ) : IrGeneratorContext by defaultGenerator

--- a/spockk-docs/docs/changelog.md
+++ b/spockk-docs/docs/changelog.md
@@ -7,6 +7,11 @@ title: Changelog
 
 # Changelog
 
+## v0.6.0
+
+- [Core] Added support for `thrown`/`notThrown`/`noExceptionThrown` exception conditions
+- Regular dependency management
+
 ## v0.5.1
 
 - [Core] Support nullable data provider arguments

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/condition/ExceptionConditionValidationTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/condition/ExceptionConditionValidationTest.kt
@@ -46,6 +46,50 @@ class ExceptionConditionValidationTest : BaseCompilationTest() {
     result.compilation.messages.contains("A 'then' block may only have a single exception condition")
   }
 
+  fun `rejects a captured thrown() alongside a different bare notThrown()`() {
+    `when`
+    val result =
+      transform(
+        specWithFeatureBody(
+          """
+          io.github.pshevche.spockk.lang.`when`
+          "".substring(5)
+
+          io.github.pshevche.spockk.lang.then
+          val e = thrown(StringIndexOutOfBoundsException::class.java)
+          notThrown(IllegalArgumentException::class.java)
+          """
+            .trimIndent()
+        )
+      )
+
+    then
+    !result.isSuccess()
+    result.compilation.messages.contains("A 'then' block may only have a single exception condition")
+  }
+
+  fun `rejects the same thrown() call appearing twice`() {
+    `when`
+    val result =
+      transform(
+        specWithFeatureBody(
+          """
+          io.github.pshevche.spockk.lang.`when`
+          "".substring(5)
+
+          io.github.pshevche.spockk.lang.then
+          thrown(StringIndexOutOfBoundsException::class.java)
+          thrown(StringIndexOutOfBoundsException::class.java)
+          """
+            .trimIndent()
+        )
+      )
+
+    then
+    !result.isSuccess()
+    result.compilation.messages.contains("A 'then' block may only have a single exception condition")
+  }
+
   fun `accepts a single exception condition alongside an ordinary condition`() {
     `when`
     val result =

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/condition/ExceptionConditionValidationTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/condition/ExceptionConditionValidationTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.condition
+
+import io.github.pshevche.spockk.compilation.BaseCompilationTest
+import io.github.pshevche.spockk.compilation.TestDataFactory.specWithFeatureBody
+import io.github.pshevche.spockk.fixtures.compilation.CompilationUtils.transform
+import io.github.pshevche.spockk.lang.then
+import io.github.pshevche.spockk.lang.`when`
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+@OptIn(ExperimentalCompilerApi::class)
+class ExceptionConditionValidationTest : BaseCompilationTest() {
+
+  fun `rejects a then block with more than one exception condition`() {
+    `when`
+    val result =
+      transform(
+        specWithFeatureBody(
+          """
+          io.github.pshevche.spockk.lang.`when`
+          "".substring(5)
+
+          io.github.pshevche.spockk.lang.then
+          thrown(StringIndexOutOfBoundsException::class.java)
+          noExceptionThrown()
+          """
+            .trimIndent()
+        )
+      )
+
+    then
+    !result.isSuccess()
+    result.compilation.messages.contains("A 'then' block may only have a single exception condition")
+  }
+
+  fun `accepts a single exception condition alongside an ordinary condition`() {
+    `when`
+    val result =
+      transform(
+        specWithFeatureBody(
+          """
+          io.github.pshevche.spockk.lang.`when`
+          "".substring(5)
+
+          io.github.pshevche.spockk.lang.then
+          val e: StringIndexOutOfBoundsException = thrown(StringIndexOutOfBoundsException::class.java)
+          e.message != null
+          """
+            .trimIndent()
+        )
+      )
+
+    then
+    result.isSuccess()
+  }
+}

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/condition/ExceptionConditionsCompilationTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/compilation/condition/ExceptionConditionsCompilationTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.compilation.condition
+
+import io.github.pshevche.spockk.compilation.BaseCompilationTest
+import io.github.pshevche.spockk.compilation.TransformationSample.Companion.sampleFromResource
+import io.github.pshevche.spockk.lang.expect
+
+/**
+ * Covers the `when`-block wrapping mechanism ([io.github.pshevche.spockk.compilation.transformer.condition.WhenBlockRewriter])
+ * with exact-IR-shape snapshots. `thrown(Type)`'s own call-site rewrite
+ * ([io.github.pshevche.spockk.compilation.transformer.condition.ExceptionConditionRewriter]) is
+ * deliberately not snapshot-tested here: the rewritten cast target type carries a Java
+ * `@FlexibleNullability` platform-type marker (from `Specification.thrown`'s generic Java
+ * signature) that ordinary hand-written Kotlin source cannot reproduce byte-for-byte, so its
+ * correctness is covered by [io.github.pshevche.spockk.smoke.condition.ExceptionConditionsSmokeTest]
+ * (runtime pass/fail behavior) instead.
+ */
+class ExceptionConditionsCompilationTest : BaseCompilationTest() {
+
+  fun `when block wrapped for a paired notThrown call`() {
+    expect
+    assertTransformation(sampleFromResource("condition/NotThrown"))
+  }
+
+  fun `when block wrapped for a paired noExceptionThrown call`() {
+    expect
+    assertTransformation(sampleFromResource("condition/NoExceptionThrown"))
+  }
+
+  fun `when block is left unwrapped without a paired exception condition`() {
+    expect
+    assertTransformation(sampleFromResource("condition/NoExceptionConditionNoWrapping"))
+  }
+}

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.smoke.condition
+
+import io.github.pshevche.spockk.lang.expect
+import io.github.pshevche.spockk.lang.then
+import io.github.pshevche.spockk.lang.`when`
+import org.spockframework.runtime.InvalidSpecException
+import spock.lang.FailsWith
+import spock.lang.Specification
+
+/**
+ * Pins the *current* behavior of Spock's `thrown()`/`notThrown()`/`noExceptionThrown()`
+ * exception-condition helpers under Spockk, mirroring the scenarios covered by Spock's own
+ * `ExceptionConditions` spec.
+ *
+ * Unlike real Spock, Spockk's `when` blocks are never wrapped in a try/catch that records the
+ * thrown exception on `SpecificationContext` (see `FeatureRewriter`/`ConditionRewriter`, which
+ * have no equivalent of Spock's `SpecRewriter.rewriteWhenBlockForExceptionCondition`). As a
+ * result none of these helpers work as documented yet: `when`-block exceptions always propagate
+ * raw instead of being caught, `thrown()` unconditionally throws `InvalidSpecException` (its
+ * un-rewritten fallback body), and `notThrown()`/`noExceptionThrown()` silently no-op because
+ * `getThrownException()` is never populated. These tests document that gap as a regression
+ * baseline rather than the intended behavior.
+ */
+class ExceptionConditionsSmokeTest : Specification() {
+
+  @FailsWith(IndexOutOfBoundsException::class)
+  fun `thrown() does not catch the when-block exception`() {
+    `when`
+    "".substring(5)
+
+    then
+    thrown(IndexOutOfBoundsException::class.java)
+  }
+
+  @FailsWith(InvalidSpecException::class)
+  fun `thrown() always throws even when the when-block does not throw`() {
+    `when`
+    val x = 1
+
+    then
+    thrown(RuntimeException::class.java)
+  }
+
+  fun `noExceptionThrown() passes, but only vacuously since it never observes the when-block`() {
+    `when`
+    val x = 1
+
+    then
+    noExceptionThrown()
+  }
+
+  @FailsWith(IllegalStateException::class)
+  fun `noExceptionThrown() does not catch the exception it should reject`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    noExceptionThrown()
+  }
+
+  @FailsWith(IllegalStateException::class)
+  fun `notThrown() does not catch the exception it should reject`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    notThrown(IllegalStateException::class.java)
+  }
+
+  fun `notThrown() passes, but only vacuously since it never observes the when-block`() {
+    `when`
+    val x = 1
+
+    then
+    notThrown(IllegalArgumentException::class.java)
+  }
+}

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
@@ -35,8 +35,8 @@ import java.io.IOException
  * ([io.github.pshevche.spockk.compilation.transformer.condition.ExceptionConditionRewriter]).
  *
  * Deliberately out of scope (see the design doc, `_docs/specs/2026-08-09-exception-conditions-design.md`):
- * zero-arg `thrown()` with type inferred from a `val` declaration, and nested (non-top-level)
- * exception-condition calls.
+ * zero-arg `thrown()` used as a bare statement (no `val`/`var` to infer a type from), and nested
+ * (non-top-level) exception-condition calls.
  */
 class ExceptionConditionsSmokeTest : Specification() {
 
@@ -57,6 +57,24 @@ class ExceptionConditionsSmokeTest : Specification() {
     then
     val e: IndexOutOfBoundsException = thrown(IndexOutOfBoundsException::class.java)
     e.message != null
+  }
+
+  fun `infers the exception type from a zero-arg thrown() assigned to a val`() {
+    `when`
+    "".substring(5)
+
+    then
+    val e: IndexOutOfBoundsException = thrown()
+    e.message != null
+  }
+
+  @FailsWith(InvalidSpecException::class)
+  fun `zero-arg thrown() as a bare statement is not rewritten and always throws`() {
+    `when`
+    "".substring(5)
+
+    then
+    thrown<IndexOutOfBoundsException>()
   }
 
   fun `catches a RuntimeException`() {

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
@@ -18,27 +18,31 @@ import io.github.pshevche.spockk.lang.expect
 import io.github.pshevche.spockk.lang.then
 import io.github.pshevche.spockk.lang.`when`
 import org.spockframework.runtime.InvalidSpecException
+import org.spockframework.runtime.UnallowedExceptionThrownError
+import org.spockframework.runtime.WrongExceptionThrownError
 import spock.lang.FailsWith
 import spock.lang.Specification
+import java.io.IOException
 
 /**
- * Pins the *current* behavior of Spock's `thrown()`/`notThrown()`/`noExceptionThrown()`
- * exception-condition helpers under Spockk, mirroring the scenarios covered by Spock's own
- * `ExceptionConditions` spec.
+ * Exercises Spock's exception-condition helpers - `thrown()`, `notThrown()`, `noExceptionThrown()`
+ * - mirroring the scenarios covered by Spock's own `ExceptionConditions` spec. A `when` block
+ * paired with a `then` block containing one of these calls has its statements wrapped in a
+ * try/catch that records the thrown exception on `SpecificationContext`
+ * ([io.github.pshevche.spockk.compilation.transformer.condition.WhenBlockRewriter]);
+ * `thrown(Type::class.java)` is rewritten to call Spock's own already-shaded
+ * `SpecInternals.checkExceptionThrown`
+ * ([io.github.pshevche.spockk.compilation.transformer.condition.ExceptionConditionRewriter]).
  *
- * Unlike real Spock, Spockk's `when` blocks are never wrapped in a try/catch that records the
- * thrown exception on `SpecificationContext` (see `FeatureRewriter`/`ConditionRewriter`, which
- * have no equivalent of Spock's `SpecRewriter.rewriteWhenBlockForExceptionCondition`). As a
- * result none of these helpers work as documented yet: `when`-block exceptions always propagate
- * raw instead of being caught, `thrown()` unconditionally throws `InvalidSpecException` (its
- * un-rewritten fallback body), and `notThrown()`/`noExceptionThrown()` silently no-op because
- * `getThrownException()` is never populated. These tests document that gap as a regression
- * baseline rather than the intended behavior.
+ * Deliberately out of scope (see the design doc, `_docs/specs/2026-08-09-exception-conditions-design.md`):
+ * zero-arg `thrown()` with type inferred from a `val` declaration, chained `then` blocks after one
+ * `when`, and nested (non-top-level) exception-condition calls.
  */
 class ExceptionConditionsSmokeTest : Specification() {
 
-  @FailsWith(IndexOutOfBoundsException::class)
-  fun `thrown() does not catch the when-block exception`() {
+  private class CustomError : Error()
+
+  fun `catches the thrown exception`() {
     `when`
     "".substring(5)
 
@@ -46,16 +50,81 @@ class ExceptionConditionsSmokeTest : Specification() {
     thrown(IndexOutOfBoundsException::class.java)
   }
 
-  @FailsWith(InvalidSpecException::class)
-  fun `thrown() always throws even when the when-block does not throw`() {
+  fun `captures the thrown exception into a variable`() {
     `when`
-    val x = 1
+    "".substring(5)
 
     then
-    thrown(RuntimeException::class.java)
+    val e: IndexOutOfBoundsException = thrown(IndexOutOfBoundsException::class.java)
+    e.message != null
   }
 
-  fun `noExceptionThrown() passes, but only vacuously since it never observes the when-block`() {
+  fun `catches a RuntimeException`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    thrown(IllegalStateException::class.java)
+  }
+
+  fun `catches a checked Exception`() {
+    `when`
+    throw IOException("boom")
+
+    then
+    thrown(IOException::class.java)
+  }
+
+  fun `catches an Error`() {
+    `when`
+    throw CustomError()
+
+    then
+    thrown(CustomError::class.java)
+  }
+
+  fun `catches the base Throwable type`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    val t: Throwable = thrown(Throwable::class.java)
+    t is IllegalStateException
+  }
+
+  @FailsWith(WrongExceptionThrownError::class)
+  fun `rejects the wrong exception type`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    thrown(IllegalArgumentException::class.java)
+  }
+
+  @FailsWith(InvalidSpecException::class)
+  fun `thrown(null) fails since the type cannot be inferred`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    thrown<RuntimeException>(null)
+  }
+
+  fun `each when-then pair catches its own exception independently`() {
+    `when`
+    throw IOException("first")
+
+    then
+    thrown(IOException::class.java)
+
+    `when`
+    throw IllegalStateException("second")
+
+    then
+    thrown(IllegalStateException::class.java)
+  }
+
+  fun `noExceptionThrown passes when nothing is thrown`() {
     `when`
     val x = 1
 
@@ -63,8 +132,8 @@ class ExceptionConditionsSmokeTest : Specification() {
     noExceptionThrown()
   }
 
-  @FailsWith(IllegalStateException::class)
-  fun `noExceptionThrown() does not catch the exception it should reject`() {
+  @FailsWith(UnallowedExceptionThrownError::class)
+  fun `noExceptionThrown rejects any thrown exception`() {
     `when`
     throw IllegalStateException("boom")
 
@@ -72,8 +141,16 @@ class ExceptionConditionsSmokeTest : Specification() {
     noExceptionThrown()
   }
 
-  @FailsWith(IllegalStateException::class)
-  fun `notThrown() does not catch the exception it should reject`() {
+  fun `notThrown passes when nothing is thrown`() {
+    `when`
+    val x = 1
+
+    then
+    notThrown(IllegalStateException::class.java)
+  }
+
+  @FailsWith(UnallowedExceptionThrownError::class)
+  fun `notThrown rejects a matching exception`() {
     `when`
     throw IllegalStateException("boom")
 
@@ -81,11 +158,18 @@ class ExceptionConditionsSmokeTest : Specification() {
     notThrown(IllegalStateException::class.java)
   }
 
-  fun `notThrown() passes, but only vacuously since it never observes the when-block`() {
+  @FailsWith(IllegalStateException::class)
+  fun `notThrown rethrows an exception of a different type`() {
     `when`
-    val x = 1
+    throw IllegalStateException("boom")
 
     then
     notThrown(IllegalArgumentException::class.java)
+  }
+
+  @FailsWith(InvalidSpecException::class)
+  fun `thrown() in an expect block is not rewritten and always throws`() {
+    expect
+    thrown(RuntimeException::class.java)
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/condition/ExceptionConditionsSmokeTest.kt
@@ -35,8 +35,8 @@ import java.io.IOException
  * ([io.github.pshevche.spockk.compilation.transformer.condition.ExceptionConditionRewriter]).
  *
  * Deliberately out of scope (see the design doc, `_docs/specs/2026-08-09-exception-conditions-design.md`):
- * zero-arg `thrown()` with type inferred from a `val` declaration, chained `then` blocks after one
- * `when`, and nested (non-top-level) exception-condition calls.
+ * zero-arg `thrown()` with type inferred from a `val` declaration, and nested (non-top-level)
+ * exception-condition calls.
  */
 class ExceptionConditionsSmokeTest : Specification() {
 
@@ -171,5 +171,25 @@ class ExceptionConditionsSmokeTest : Specification() {
   fun `thrown() in an expect block is not rewritten and always throws`() {
     expect
     thrown(RuntimeException::class.java)
+  }
+
+  @FailsWith(IllegalStateException::class)
+  fun `thrown() nested inside an if is not rewritten, so the raw exception propagates`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    if (true) {
+      thrown(IllegalStateException::class.java)
+    }
+  }
+
+  @FailsWith(IllegalStateException::class)
+  fun `thrown() used as a function argument is not rewritten, so the raw exception propagates`() {
+    `when`
+    throw IllegalStateException("boom")
+
+    then
+    println(thrown(IllegalStateException::class.java))
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/source/condition/NoExceptionConditionNoWrapping.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/source/condition/NoExceptionConditionNoWrapping.kt
@@ -1,0 +1,9 @@
+class NoExceptionConditionNoWrapping : spock.lang.Specification() {
+  fun `some feature`() {
+    io.github.pshevche.spockk.lang.`when`
+    val x = 1
+
+    io.github.pshevche.spockk.lang.then
+    true
+  }
+}

--- a/spockk-specs/src/test/resources/samples/compilation/source/condition/NoExceptionThrown.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/source/condition/NoExceptionThrown.kt
@@ -1,0 +1,9 @@
+class NoExceptionThrown : spock.lang.Specification() {
+  fun `some feature`() {
+    io.github.pshevche.spockk.lang.`when`
+    check(true)
+
+    io.github.pshevche.spockk.lang.then
+    noExceptionThrown()
+  }
+}

--- a/spockk-specs/src/test/resources/samples/compilation/source/condition/NotThrown.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/source/condition/NotThrown.kt
@@ -1,0 +1,9 @@
+class NotThrown : spock.lang.Specification() {
+  fun `some feature`() {
+    io.github.pshevche.spockk.lang.`when`
+    check(false)
+
+    io.github.pshevche.spockk.lang.then
+    notThrown(IllegalArgumentException::class.java)
+  }
+}

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/condition/NoExceptionConditionNoWrapping.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/condition/NoExceptionConditionNoWrapping.kt
@@ -1,0 +1,48 @@
+@org.spockframework.runtime.model.SpecMetadata(filename = "NoExceptionConditionNoWrapping.kt", line = 1)
+class NoExceptionConditionNoWrapping : spock.lang.Specification() {
+  @org.spockframework.runtime.model.FeatureMetadata(
+    ordinal = 0,
+    name = "some feature",
+    line = 2,
+    parameterNames = [],
+    blocks = [
+      org.spockframework.runtime.model.BlockMetadata(
+        org.spockframework.runtime.model.BlockKind.WHEN,
+        [""]
+      ),
+      org.spockframework.runtime.model.BlockMetadata(
+        org.spockframework.runtime.model.BlockKind.THEN,
+        [""]
+      )
+    ]
+  )
+  fun `$spock_feature_0_0`() {
+    val `$spock_valueRecorder` : org.spockframework.runtime.ValueRecorder = org.spockframework.runtime.ValueRecorder()
+    val `$spock_errorCollector` : org.spockframework.runtime.ErrorCollector =
+      org.spockframework.runtime.ErrorRethrower.INSTANCE
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
+    val x = 1
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
+    try {
+      org.spockframework.runtime.SpockRuntime.verifyCondition(`$spock_errorCollector`,
+        `$spock_valueRecorder`.reset(),
+        "true",
+        7,
+        5,
+        null,
+        `$spock_valueRecorder`.record(`$spock_valueRecorder`.startRecordingValue(0), true) as Boolean)
+    }
+    catch (`$spock_condition_throwable` : Throwable) {
+      org.spockframework.runtime.SpockRuntime.conditionFailedWithException(`$spock_errorCollector`,
+        `$spock_valueRecorder`,
+        "true",
+        7,
+        5,
+        null,
+        `$spock_condition_throwable`)}
+    finally {
+    }
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
+  }
+}

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/condition/NoExceptionThrown.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/condition/NoExceptionThrown.kt
@@ -1,0 +1,33 @@
+@org.spockframework.runtime.model.SpecMetadata(filename = "NoExceptionThrown.kt", line = 1)
+class NoExceptionThrown : spock.lang.Specification() {
+  @org.spockframework.runtime.model.FeatureMetadata(
+    ordinal = 0,
+    name = "some feature",
+    line = 2,
+    parameterNames = [],
+    blocks = [
+      org.spockframework.runtime.model.BlockMetadata(
+        org.spockframework.runtime.model.BlockKind.WHEN,
+        [""]
+      ),
+      org.spockframework.runtime.model.BlockMetadata(
+        org.spockframework.runtime.model.BlockKind.THEN,
+        [""]
+      )
+    ]
+  )
+  fun `$spock_feature_0_0`() {
+    (this.getSpecificationContext() as org.spockframework.runtime.SpecificationContext).setThrownException(null)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
+    try {
+      check(true)
+    } catch (`$spock_when_throwable`: Throwable) {
+      (this.getSpecificationContext() as org.spockframework.runtime.SpecificationContext).setThrownException(`$spock_when_throwable`)
+    } finally {
+    }
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
+    noExceptionThrown()
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
+  }
+}

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/condition/NotThrown.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/condition/NotThrown.kt
@@ -1,0 +1,33 @@
+@org.spockframework.runtime.model.SpecMetadata(filename = "NotThrown.kt", line = 1)
+class NotThrown : spock.lang.Specification() {
+  @org.spockframework.runtime.model.FeatureMetadata(
+    ordinal = 0,
+    name = "some feature",
+    line = 2,
+    parameterNames = [],
+    blocks = [
+      org.spockframework.runtime.model.BlockMetadata(
+        org.spockframework.runtime.model.BlockKind.WHEN,
+        [""]
+      ),
+      org.spockframework.runtime.model.BlockMetadata(
+        org.spockframework.runtime.model.BlockKind.THEN,
+        [""]
+      )
+    ]
+  )
+  fun `$spock_feature_0_0`() {
+    (this.getSpecificationContext() as org.spockframework.runtime.SpecificationContext).setThrownException(null)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
+    try {
+      check(false)
+    } catch (`$spock_when_throwable`: Throwable) {
+      (this.getSpecificationContext() as org.spockframework.runtime.SpecificationContext).setThrownException(`$spock_when_throwable`)
+    } finally {
+    }
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
+    notThrown(IllegalArgumentException::class.java)
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
+  }
+}


### PR DESCRIPTION
## Summary

- Implements Spock's exception-condition helpers — `thrown()`, `notThrown()`, `noExceptionThrown()` — which previously didn't work at all in Spockk (`thrown()` always threw its own unconditional `InvalidSpecException` fallback; `notThrown`/`noExceptionThrown` silently no-op'd since the thrown exception was never recorded anywhere).
- A `when` block immediately followed by a `then` block containing one of these calls now gets wrapped in a try/catch that records the thrown exception on Spock's real `SpecificationContext` (`WhenBlockRewriter`), mirroring Spock's own `SpecRewriter.rewriteWhenBlockForExceptionCondition`.
- `thrown(Type::class.java)` is rewritten to call Spock's own already-shaded `SpecInternals.checkExceptionThrown` static method (`ExceptionConditionRewriter`) — no new exception-matching logic written, reusing Spock's real behavior unchanged, including its handling of `thrown(null)` and non-`Throwable` types.
- `notThrown`/`noExceptionThrown` need no call-site rewriting at all — their real inherited bodies on `Specification` already correctly read the recorded exception once the `when`-block wrapping is in place.
- Adds compile-time validation: at most one exception condition per `then` block.
- Found and fixed two real bugs along the way via direct IR-dump verification against the compiler plugin: `thrown`/`notThrown`/`noExceptionThrown` resolve to `[fake_override]` declarations in the user's spec subclass (needed to unwrap to the original `Specification` declaration before FqName matching), and call sites get wrapped in `IMPLICIT_COERCION_TO_UNIT`/`IMPLICIT_NOTNULL` type operators that needed unwrapping before detection.
- Two independent subagent code reviews (plus an initial single-pass review) found no correctness bugs; addressed the style/doc/test-coverage gaps they raised (see the last commit).

Design spec: `_docs/specs/2026-08-09-exception-conditions-design.md`. Implementation plan: `_docs/plans/2026-08-09-exception-conditions.md`.

Closes #271

## Test plan

- [x] Compilation snapshot tests (`ExceptionConditionsCompilationTest`) — verified byte-identical IR dumps against the real compiler plugin for the `when`-block wrapping mechanism (`notThrown`, `noExceptionThrown`, and the no-wrapping negative case)
- [x] Smoke tests (`ExceptionConditionsSmokeTest`) covering: basic `thrown()` usage (bare statement and `val` capture), catching `RuntimeException`/checked `Exception`/`Error`/base `Throwable`, wrong-type rejection (`WrongExceptionThrownError`), `thrown(null)` (`InvalidSpecException`), multiple independent `when`/`then` pairs, `notThrown`/`noExceptionThrown` passing and rejecting, `notThrown`'s rethrow-on-type-mismatch semantics, `expect`-block usage (unchanged, already-correct fallback), and non-top-level `thrown()` (nested `if`, function argument) degrading safely to the raw exception propagating
- [x] Compile-validation tests (`ExceptionConditionValidationTest`) for the at-most-one-exception-condition-per-`then`-block rule across multiple collision shapes
- [x] `./gradlew build` passes for every module this touches (`spockk-core`, `spockk-compiler-plugin`, `spockk-specs`, including detekt/spotless)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjsApjmqZXU6dkV2oRzyNb)_