### PR TITLE
fix(core): support nullable data provider arguments

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -9,6 +9,8 @@ runs:
         distribution: temurin
         java-version: 21
     - uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-provider: 'basic'
     - uses: testlens-app/setup-testlens@v1
 
     - name: Detect whether running on a PR from a fork

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Review and approve the spec and plan before implementation starts.
 - **Gradle Plugin Portal**: spockk-gradle-plugin (ID: `io.github.pshevche.spockk`)
 - **JetBrains Marketplace**: spockk-intellij-plugin
 - **GitHub Pages**: spockk-docs
-- Version defined in `gradle.properties` (currently `0.5.0`)
+- Version defined in `gradle.properties`
 
 ## Git Conventions
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.java.installations.fromEnv=JDK21
 org.gradle.jvmargs=-Xmx2g "-XX:MaxMetaspaceSize=1g"
 kotlin.daemon.jvmargs=-Xmx1g
 group=io.github.pshevche.spockk
-version=0.5.0
+version=0.5.1

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/parametrization/WhereBlockRewriter.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/parametrization/WhereBlockRewriter.kt
@@ -64,6 +64,7 @@ import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.isArray
+import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.file
@@ -343,7 +344,7 @@ internal class WhereBlockRewriter(
   private fun createDataProcessorParameter(nextDataVariableIndex: Int): IrValueParameter =
     dataProcessorMethod.addValueParameter(
       Name.identifier("spock_p$nextDataVariableIndex"),
-      irBuiltIns.anyType
+      irBuiltIns.anyType.makeNullable()
     )
 
   private fun createDataProcessorVariable(featureVariable: IrValueParameter): IrVariable =
@@ -504,7 +505,7 @@ internal class WhereBlockRewriter(
       dataProcessorMethod.annotations += createDataProcessorAnnotation(this)
       dataProcessorMethod
         .mutableStatements()
-        ?.add(irReturn(irArrayOf(irBuiltIns.anyType, dataProcessorVars.map { irGet(it) })))
+        ?.add(irReturn(irArrayOf(irBuiltIns.anyType.makeNullable(), dataProcessorVars.map { irGet(it) })))
     }
   }
 

--- a/spockk-docs/docs/changelog.md
+++ b/spockk-docs/docs/changelog.md
@@ -7,6 +7,11 @@ title: Changelog
 
 # Changelog
 
+## v0.5.1
+
+- [Core] Support nullable data provider arguments
+- Regular dependency management
+
 ## v0.5.0
 
 - [Core] Added support for implicit conditions in expectation blocks

--- a/spockk-intellij-plugin/docs/release-notes.txt
+++ b/spockk-intellij-plugin/docs/release-notes.txt
@@ -1,4 +1,3 @@
 <ul>
-    <li>Added syntax support for implicit condition statements.</li>
-    <li>Regular dependency management.</li>
+    <li>Regular dependency management</li>
 </ul>

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/parametrization/DataPipesSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/parametrization/DataPipesSmokeTest.kt
@@ -18,6 +18,7 @@ import io.github.pshevche.spockk.lang.expect
 import io.github.pshevche.spockk.lang.variable
 import io.github.pshevche.spockk.lang.variables
 import io.github.pshevche.spockk.lang.where
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 import kotlin.math.max
@@ -104,5 +105,21 @@ class DataPipesSmokeTest : Specification() {
     variable(a).from(0)
     variable(b).from(a + 1)
     variable(c).from(b + 1)
+  }
+
+  @Issue("https://github.com/pshevche/spockk/issues/276")
+  fun `data pipes with optional arguments`(
+    actual: Boolean?,
+    expected: Boolean?
+  ) {
+    expect
+    specificationContext.currentIteration.estimatedNumIterations == 3
+    actual == expected
+
+    where
+    variables(actual, expected).from(
+      listOf(false, true, null),
+      listOf(false, true, null)
+    )
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/parametrization/DataTablesSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/parametrization/DataTablesSmokeTest.kt
@@ -18,6 +18,7 @@ import io.github.pshevche.spockk.lang.and
 import io.github.pshevche.spockk.lang.expect
 import io.github.pshevche.spockk.lang.variable
 import io.github.pshevche.spockk.lang.where
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 import kotlin.math.max
@@ -224,4 +225,21 @@ class DataTablesSmokeTest : Specification() {
     3 ; y ; y + z
     4 ; y ; y + z
   }
+
+  @Issue("https://github.com/pshevche/spockk/issues/276")
+  fun `data tables with optional arguments`(
+    actual: Boolean?,
+    expected: Boolean?
+  ) {
+    expect
+    specificationContext.currentIteration.estimatedNumIterations == 3
+    actual == expected
+
+    where
+    actual ; expected
+    false  ; false
+    true   ; true
+    null   ; null
+  }
+
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/parametrization/DataTablesSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/parametrization/DataTablesSmokeTest.kt
@@ -241,5 +241,4 @@ class DataTablesSmokeTest : Specification() {
     true   ; true
     null   ; null
   }
-
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/cleanup/CleanupBlockWithWhere.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/cleanup/CleanupBlockWithWhere.kt
@@ -80,9 +80,9 @@ class CleanupBlockWithWhere : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?): Any {
     var a: Int
     a = ((spock_p0) as Int)
-    return arrayOf<Any>(a)
+    return arrayOf<Any?>(a)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/BasicDataTableSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/BasicDataTableSpec.kt
@@ -60,13 +60,13 @@ class BasicDataTableSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a", "b", "c"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any, spock_p1: Any, spock_p2: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?, spock_p1: Any?, spock_p2: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
     var b: Int
     b = (( spock_p1 ) as Int)
     var c: Int
     c = (( spock_p2 ) as Int)
-    return arrayOf<Any>(a, b, c)
+    return arrayOf<Any?>(a, b, c)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/MultiPipeMultiVariableSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/MultiPipeMultiVariableSpec.kt
@@ -61,13 +61,13 @@ class MultiPipeMultiVariableSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a", "b", "c"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any, spock_p1: Any, spock_p2: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?, spock_p1: Any?, spock_p2: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
     var b: Int
     b = (( spock_p1 ) as Int)
     var c: Int
     c = (( spock_p2 ) as Int)
-    return arrayOf<Any>(a, b, c)
+    return arrayOf<Any?>(a, b, c)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/ReferenceFeatureVariableInDataPipeSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/ReferenceFeatureVariableInDataPipeSpec.kt
@@ -52,11 +52,11 @@ class ReferenceFeatureVariableInDataPipeSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a", "b"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
     var b: Int
     b = (( a + 1 ) as Int)
-    return arrayOf<Any>(a, b)
+    return arrayOf<Any?>(a, b)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/ReferenceFeatureVariableInDataTableSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/ReferenceFeatureVariableInDataTableSpec.kt
@@ -59,11 +59,11 @@ class ReferenceFeatureVariableInDataTableSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a", "b"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any, spock_p1: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?, spock_p1: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
     var b: Int
     b = (( spock_p1 ) as Int)
-    return arrayOf<Any>(a, b)
+    return arrayOf<Any?>(a, b)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SinglePipeMultiVariableSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SinglePipeMultiVariableSpec.kt
@@ -61,13 +61,13 @@ class SinglePipeMultiVariableSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a", "b", "c"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any, spock_p1: Any, spock_p2: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?, spock_p1: Any?, spock_p2: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
     var b: Int
     b = (( spock_p1 ) as Int)
     var c: Int
     c = (( spock_p2 ) as Int)
-    return arrayOf<Any>(a, b, c)
+    return arrayOf<Any?>(a, b, c)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SingleVariableSingleValueSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SingleVariableSingleValueSpec.kt
@@ -48,6 +48,6 @@ class SingleVariableSingleValueSpec : spock.lang.Specification() {
   fun `$spock_feature_0_0proc`(): Any {
     var a: Int
     a = (( 1 ) as Int)
-    return arrayOf<Any>(a)
+    return arrayOf<Any?>(a)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SingleVariableValuesListSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SingleVariableValuesListSpec.kt
@@ -53,9 +53,9 @@ class SingleVariableValuesListSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
-    return arrayOf<Any>(a)
+    return arrayOf<Any?>(a)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SingleVariableVarargValuesSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/SingleVariableVarargValuesSpec.kt
@@ -51,9 +51,9 @@ class SingleVariableVarargValuesSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
-    return arrayOf<Any>(a)
+    return arrayOf<Any?>(a)
   }
 }

--- a/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/WildcardDataTableSpec.kt
+++ b/spockk-specs/src/test/resources/samples/compilation/transformed/parametrization/WildcardDataTableSpec.kt
@@ -50,10 +50,10 @@ class WildcardDataTableSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a"])
-  fun `$spock_feature_0_0proc`(spock_p0: Any): Any {
+  fun `$spock_feature_0_0proc`(spock_p0: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
-    return arrayOf<Any>(a)
+    return arrayOf<Any?>(a)
   }
 
   @org.spockframework.runtime.model.FeatureMetadata(
@@ -113,12 +113,12 @@ class WildcardDataTableSpec : spock.lang.Specification() {
   }
 
   @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ["a", "_"])
-  fun `$spock_feature_0_1proc`(spock_p0: Any, spock_p1: Any): Any {
+  fun `$spock_feature_0_1proc`(spock_p0: Any?, spock_p1: Any?): Any {
     var a: Int
     a = (( spock_p0 ) as Int)
     var `_`: Any
     `_` = (( spock_p1 ) as Any)
-    return arrayOf<Any>(a, `_`)
+    return arrayOf<Any?>(a, `_`)
   }
 }
 


### PR DESCRIPTION
## Description

Prior to this change, the generated data processor method's parameters and return values did not support nullable types.

Resolves #276