### PR TITLE
fix: preserve @get:Rule/@get:ClassRule on rewritten backing field

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 auto-service = "1.1.1"
 junit = "6.1.3"
 kotlin = "2.4.10"
+spock = "2.4-groovy-5.0"
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "6.0.10" }
@@ -25,5 +26,6 @@ junit4 = { module = "junit:junit", version = "4.13.2" }
 
 kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.13.0" }
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-spock = { module = "org.spockframework:spock-core", version = "2.4-groovy-5.0" }
+spock = { module = "org.spockframework:spock-core", version.ref = "spock" }
+spock-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "spock" }
 mockito = { module = "org.mockito:mockito-core", version = "5.23.0" }

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrIdentifiers.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/ir/IrIdentifiers.kt
@@ -78,6 +78,13 @@ internal object IrIdentifiers {
     val FROM_FQN_REGEX = "io\\.github\\.pshevche\\.spockk\\.lang\\.DataVariable.+\\.from".toRegex()
   }
 
+  internal object JUnit {
+    // FqName
+    private val JUNIT_PKG_FQN = FqName("org.junit")
+    val RULE_FQN = JUNIT_PKG_FQN.child("Rule")
+    val CLASS_RULE_FQN = JUNIT_PKG_FQN.child("ClassRule")
+  }
+
   internal object Kotlin {
     // FqName
     val LIST_FQN = COLLECTIONS_PACKAGE_FQ_NAME.child("List")

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/FieldStrategyBase.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/FieldStrategyBase.kt
@@ -17,6 +17,8 @@
 package io.github.pshevche.spockk.compilation.transformer.fields
 
 import io.github.pshevche.spockk.compilation.ir.IrDeclarationOriginWrapper
+import io.github.pshevche.spockk.compilation.ir.IrIdentifiers.JUnit.CLASS_RULE_FQN
+import io.github.pshevche.spockk.compilation.ir.IrIdentifiers.JUnit.RULE_FQN
 import io.github.pshevche.spockk.compilation.ir.IrIdentifiers.Spock.FIELD_METADATA_FQN
 import io.github.pshevche.spockk.compilation.ir.addMemberFunction
 import io.github.pshevche.spockk.compilation.ir.irAnnotation
@@ -44,6 +46,7 @@ import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.name.Name
 
 internal abstract class FieldStrategyBase(
@@ -54,7 +57,7 @@ internal abstract class FieldStrategyBase(
 
   // --- Annotation ---
 
-  protected fun annotateField(field: IrField, fieldCtx: FieldContext) {
+  protected fun annotateField(field: IrField, property: IrProperty, fieldCtx: FieldContext) {
     with(irBuilder(field.symbol)) {
       field.annotations += irAnnotation(
         FIELD_METADATA_FQN,
@@ -63,6 +66,18 @@ internal abstract class FieldStrategyBase(
         irInt(fieldCtx.line),
         irBoolean(fieldCtx.hasInitializer)
       )
+    }
+    copyRuleAnnotationsFromGetterToField(field, property)
+  }
+
+  // spock-junit4's RuleExtension discovers @Rule/@ClassRule by reflecting on the spec's
+  // declared fields (FieldInfo wraps java.lang.reflect.Field), never on methods. A `@get:`
+  // use-site target puts the annotation on the property's getter instead, where the
+  // extension never looks - copy it onto the backing field so the rule is found.
+  private fun copyRuleAnnotationsFromGetterToField(field: IrField, property: IrProperty) {
+    val getter = property.getter ?: return
+    listOf(RULE_FQN, CLASS_RULE_FQN).forEach { fqn ->
+      getter.getAnnotation(fqn)?.let { field.annotations += it }
     }
   }
 

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/SharedFieldStrategy.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/SharedFieldStrategy.kt
@@ -67,7 +67,7 @@ internal class SharedFieldStrategy(
     val field = property.backingField ?: return
     val isOverride = property.overriddenSymbols.isNotEmpty()
 
-    annotateField(field, fieldCtx)
+    annotateField(field, property, fieldCtx)
 
     val newName = InternalIdentifiers.getSharedFieldName(fieldCtx.name)
     rename(field, property, newName, isOverride)

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/ValFieldStrategy.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/ValFieldStrategy.kt
@@ -55,7 +55,7 @@ internal class ValFieldStrategy(
   override fun rewrite(property: IrProperty) {
     val field = property.backingField ?: return
 
-    annotateField(field, fieldCtx)
+    annotateField(field, property, fieldCtx)
 
     val newName = InternalIdentifiers.getFinalFieldName(fieldCtx.name)
     rename(field, property, newName)

--- a/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/VarFieldStrategy.kt
+++ b/spockk-compiler-plugin/src/main/kotlin/io/github/pshevche/spockk/compilation/transformer/fields/VarFieldStrategy.kt
@@ -36,7 +36,7 @@ internal class VarFieldStrategy(
   override fun rewrite(property: IrProperty) {
     val field = property.backingField ?: return
 
-    annotateField(field, fieldCtx)
+    annotateField(field, property, fieldCtx)
     field.makePrivate()
     property.makePrivate()
 

--- a/spockk-specs/build.gradle.kts
+++ b/spockk-specs/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
   testImplementation(gradleTestKit())
   testImplementation(libs.junit.platform.testkit)
   testImplementation(libs.kotlin.compile.testing)
+  testImplementation(libs.spock.junit4)
+  testImplementation(libs.junit4)
 
   testRuntimeOnly(libs.junit.platform.launcher)
   testRuntimeOnly(libs.mockito)

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/JUnit4ClassRuleSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/JUnit4ClassRuleSmokeTest.kt
@@ -16,22 +16,23 @@ package io.github.pshevche.spockk.smoke
 
 import io.github.pshevche.spockk.lang.expect
 import io.github.pshevche.spockk.lang.given
-import org.junit.Rule
+import org.junit.ClassRule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
 import spock.lang.Specification
 import java.io.File
 
-class JUnit4RuleSmokeTest : Specification() {
+/**
+ * `@ClassRule` requires a `@Shared` field (JUnit4 enforces this via AbstractRuleExtension).
+ * Unlike `@Rule`, the rule instance is shared across all features in the spec.
+ */
+class JUnit4ClassRuleSmokeTest : Specification() {
 
-  @get:Rule
+  @Shared
+  @get:ClassRule
   val tmp = TemporaryFolder()
 
-  fun `rule creates the temp folder before the feature runs`() {
-    expect
-    tmp.root.isDirectory
-  }
-
-  fun `first feature writes a marker file into its temp folder`() {
+  fun `first feature writes a marker file into the shared temp folder`() {
     given
     tmp.newFile("marker.txt")
 
@@ -39,8 +40,8 @@ class JUnit4RuleSmokeTest : Specification() {
     File(tmp.root, "marker.txt").exists()
   }
 
-  fun `next feature gets a fresh temp folder without the previous marker file`() {
+  fun `second feature still sees the marker file from the previous feature`() {
     expect
-    !File(tmp.root, "marker.txt").exists()
+    File(tmp.root, "marker.txt").exists()
   }
 }

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/JUnit4RuleSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/JUnit4RuleSmokeTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.pshevche.spockk.smoke
+
+import io.github.pshevche.spockk.lang.expect
+import io.github.pshevche.spockk.lang.given
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+import java.io.File
+
+/**
+ * `@get:Rule` is a use-site target: Kotlin puts the annotation on the property's getter, not
+ * the backing field. spock-junit4's RuleExtension only ever looks at fields, so the rewrite
+ * must relocate the annotation onto the rewritten backing field for the rule to run at all.
+ */
+class JUnit4RuleSmokeTest : Specification() {
+
+  @get:Rule
+  val tmp = TemporaryFolder()
+
+  fun `rule creates the temp folder before the feature runs`() {
+    expect
+    tmp.root.isDirectory
+  }
+
+  fun `first feature writes a marker file into its temp folder`() {
+    given
+    tmp.newFile("marker.txt")
+
+    expect
+    File(tmp.root, "marker.txt").exists()
+  }
+
+  fun `next feature gets a fresh temp folder without the previous marker file`() {
+    expect
+    !File(tmp.root, "marker.txt").exists()
+  }
+}
+
+/**
+ * `@ClassRule` requires a `@Shared` field (JUnit4 enforces this via AbstractRuleExtension).
+ * Unlike `@Rule`, the rule instance is shared across all features in the spec.
+ */
+class JUnit4ClassRuleSmokeTest : Specification() {
+
+  @Shared
+  @get:ClassRule
+  val tmp = TemporaryFolder()
+
+  fun `first feature writes a marker file into the shared temp folder`() {
+    given
+    tmp.newFile("marker.txt")
+
+    expect
+    File(tmp.root, "marker.txt").exists()
+  }
+
+  fun `second feature still sees the marker file from the previous feature`() {
+    expect
+    File(tmp.root, "marker.txt").exists()
+  }
+}
+
+/**
+ * Regression guard: `@JvmField @Rule` puts the annotation directly on the field and must keep
+ * working unchanged.
+ */
+class JvmFieldRuleSmokeTest : Specification() {
+
+  @JvmField
+  @Rule
+  val tmp = TemporaryFolder()
+
+  fun `rule created via JvmField still runs`() {
+    expect
+    tmp.root.isDirectory
+  }
+}

--- a/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/JvmFieldRuleSmokeTest.kt
+++ b/spockk-specs/src/test/kotlin/io/github/pshevche/spockk/smoke/JvmFieldRuleSmokeTest.kt
@@ -15,32 +15,22 @@
 package io.github.pshevche.spockk.smoke
 
 import io.github.pshevche.spockk.lang.expect
-import io.github.pshevche.spockk.lang.given
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-import java.io.File
 
-class JUnit4RuleSmokeTest : Specification() {
+/**
+ * Regression guard: `@JvmField @Rule` puts the annotation directly on the field and must keep
+ * working unchanged.
+ */
+class JvmFieldRuleSmokeTest : Specification() {
 
-  @get:Rule
+  @JvmField
+  @Rule
   val tmp = TemporaryFolder()
 
-  fun `rule creates the temp folder before the feature runs`() {
+  fun `rule created via JvmField still runs`() {
     expect
     tmp.root.isDirectory
-  }
-
-  fun `first feature writes a marker file into its temp folder`() {
-    given
-    tmp.newFile("marker.txt")
-
-    expect
-    File(tmp.root, "marker.txt").exists()
-  }
-
-  fun `next feature gets a fresh temp folder without the previous marker file`() {
-    expect
-    !File(tmp.root, "marker.txt").exists()
   }
 }


### PR DESCRIPTION
Closes #292

## Summary

- `spock-junit4`'s `RuleExtension`/`ClassRuleExtension` discover `@Rule`/`@ClassRule` by reflecting on the spec's declared fields only (`FieldInfo` wraps `java.lang.reflect.Field`) — they never look at methods.
- A `@get:Rule`/`@get:ClassRule` use-site target puts the annotation on the property's getter, not the backing field. Spockk's field rewrite renames/regenerates the backing field but never copied that annotation over, so the rule silently never ran.
- `FieldStrategyBase.annotateField` now copies `@Rule`/`@ClassRule` from the property's getter onto the rewritten backing field, for all three field strategies (`Val`, `Var`, `Shared`). `@ClassRule` requires a `@Shared` field per JUnit4/spock-junit4's own validation (`AbstractRuleExtension.checkIsSharedField`), which routes through `SharedFieldStrategy`.
- `@JvmField @Rule` is unaffected — that annotation was already on the field, so this rewrite is a no-op for it.

## Test plan

- Added `JUnit4RuleSmokeTest.kt` with three specs run via the real Spock JUnit Platform engine (`org.spockframework:spock-junit4` + `junit:junit` added as test dependencies to `spockk-specs`):
  - `@get:Rule val tmp = TemporaryFolder()`: verifies the rule creates the folder and that each feature gets a fresh folder.
  - `@Shared @get:ClassRule val tmp = TemporaryFolder()`: verifies the folder is shared across features.
  - `@JvmField @Rule val tmp = TemporaryFolder()`: regression guard for the already-working form.
- Verified with `javap -p -v` that the compiled bytecode shows `@Rule`/`@ClassRule` on the rewritten `$spock_finalField_tmp`/`$spock_sharedField_tmp` fields, matching the issue's acceptance criteria.
- `./gradlew build` passes (the only failures are pre-existing IntelliJ sandbox VFS errors in `spockk-intellij-plugin`, unrelated to this change and to a module this PR doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3EsACRYcHKjXxqK8r7x4g

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3EsACRYcHKjXxqK8r7x4g)_